### PR TITLE
Removing retries for fetching mysql app pod state

### DIFF
--- a/litmus/director/mysql/test.yaml
+++ b/litmus/director/mysql/test.yaml
@@ -60,7 +60,6 @@
           shell: kubectl get pods {{ app_pod.stdout }} -n {{ namespace }}  | awk '{print $3}' | awk -F':' '{print $1}' | tail -n 1
           register: app_status
           until: app_status.stdout != 'Init' and app_status.stdout != 'ContainerCreating' and app_status.stdout != 'PodInitializing'
-          retries: 15
           delay: 10
           
         - name : Check if app is Running


### PR DESCRIPTION
Removing retries for fetching app pod state as it time taken by app pod to be `Running` is not definite





@harshshekhar15 