### PR TITLE
ActiveDirectory login test suite

### DIFF
--- a/litmus/director/authn-test/run_litmus_test.yml
+++ b/litmus/director/authn-test/run_litmus_test.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: ad-authentication-test
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: ad-authentication-test-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci
+        imagePullPolicy: Always
+        env:
+          - name: ADMIN_USERNAME
+            value: Administrator
+          - name: ADMIN_PASSWORD
+            value: Test@123
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/ad-authentication-test/test.yaml -i /etc/ansible/hosts -v; exit 0"]
+      imagePullSecrets:
+      - name: oep-secret

--- a/litmus/director/authn-test/run_litmus_test.yml
+++ b/litmus/director/authn-test/run_litmus_test.yml
@@ -22,6 +22,11 @@ spec:
             value: Administrator
           - name: ADMIN_PASSWORD
             value: Test@123
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./litmus/director/ad-authentication-test/test.yaml -i /etc/ansible/hosts -v; exit 0"]
       imagePullSecrets:

--- a/litmus/director/authn-test/test.yaml
+++ b/litmus/director/authn-test/test.yaml
@@ -1,0 +1,45 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name : Fetch director url
+          shell: kubectl get node -o wide | awk {'print $7'} | head -n 4 | tail -n 1
+          register: node_ip
+
+        - set_fact:
+            url : "http://{{ node_ip.stdout }}:30380"
+        ## The token response' token and authProvider can be captured to make future API calls
+        - name : Check AD login
+          uri:
+            url: "{{ url }}/v3/token"
+            method: POST
+            body_format: json
+            body:
+              {"code": "{{ ad_username }}:{{ ad_password }}", "authProvider": "adconfig"}
+            status_code: 201
+          register: login
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/authn-test/test.yaml
+++ b/litmus/director/authn-test/test.yaml
@@ -33,6 +33,18 @@
             status_code: 201
           register: login
 
+        - set_fact:
+            jwt: "{{ login.json.jwt }}"
+        - set_fact:
+            auth_cookie: "token={{ jwt }}; authProvider=adconfig;"
+        - name : Make an API request
+          uri:
+            url: "{{ url }}/v3/identity"
+            method: GET
+            status_code: 200
+            headers:
+              Cookie: "{{auth_cookie}}"
+
       rescue:
         - name: Setting fail flag
           set_fact:

--- a/litmus/director/authn-test/test_vars.yml
+++ b/litmus/director/authn-test/test_vars.yml
@@ -1,0 +1,3 @@
+test_name: ad-authentication-test
+ad_username: "{{ lookup('env','AD_USERNAME') }}"
+ad_password: "{{ lookup('env','AD_PASSWORD') }}"

--- a/litmus/director/authn-test/test_vars.yml
+++ b/litmus/director/authn-test/test_vars.yml
@@ -1,3 +1,4 @@
 test_name: ad-authentication-test
 ad_username: "{{ lookup('env','AD_USERNAME') }}"
 ad_password: "{{ lookup('env','AD_PASSWORD') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"


### PR DESCRIPTION
This PR might have some obvious mistakes, it needs to be thoroughly reviewed, to the very least all forms of Authentication can be tested against a single API
```bash
$ curl -H 'Content-Type: application/json' https://{ABCD.XYZ.IO}/v3/token -d '{"code": "<some_secret>", "authProvider": "<some_supported_authProvider>"}'

{
...
"authProvider": "<some_supported_authProvider>",
"token": "<some_secret>"
...
}

````
HTTP status-code = 201 


Ref: https://github.com/mayadata-io/director/issues/322
fixes: https://github.com/mayadata-io/oep/issues/116