### PR TITLE
fix(upgrade): remove json_query from target pod status task

### DIFF
--- a/litmus/director/openebs-upgrade/test.yaml
+++ b/litmus/director/openebs-upgrade/test.yaml
@@ -295,9 +295,9 @@
           failed_when: "version_count.stdout!='3'"
 
         - name: Get target pod status post volume upgrade
-          shell: kubectl get po -n openebs -l app=cstor-volume-manager -o json
-          register: target
-          until: "target.stdout | from_json | json_query('items[0].status.phase')=='Running'"
+          shell: kubectl get po -n openebs -l app=cstor-volume-manager --no-headers | awk '{print $3}'
+          register: target_status
+          until: "target_status.stdout=='Running'"
           retries: 20
           delay: 2
 


### PR DESCRIPTION
Signed-off-by: Harsh Shekhar <harshshekhar15@gmail.com>

This PR intends to do the following:
- Use kubectl output to check the status of target pod instead of querying in the json output using `json_query`.