### PR TITLE
Added support to get cluster_id of self-connected cluster

### DIFF
--- a/litmus/director/admin-cluster-connect/run_litmus_test.yml
+++ b/litmus/director/admin-cluster-connect/run_litmus_test.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: admin-cluster-connect
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: admin-cluster-connect-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-admin-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+          - name: PROVIDER
+            value: gcp
+          - name: CLUSTER_NAME
+            value: OpenEBSDirector
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/admin-cluster-connect/test.yaml -i /etc/ansible/hosts -v; exit 0"]
+      imagePullSecrets:
+      - name: oep-secret

--- a/litmus/director/admin-cluster-connect/test.yaml
+++ b/litmus/director/admin-cluster-connect/test.yaml
@@ -1,0 +1,65 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+        
+        - set_fact:
+            director_url : "http://{{ director_ip }}:30380"
+
+        - name: username
+          shell: cat /etc/secret-volume/username
+          register: username
+          
+        - name: password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        - name: Fetch group id
+          shell: python3 /api_testing/group/group-id.py --url {{ director_url }} --username {{ username.stdout }} --password {{ password.stdout }}
+          register: group_id
+
+        - set_fact: 
+            group_id: "{{ group_id.stdout }}"
+
+        - name: Create configmap for admin_group_id 
+          shell: kubectl create configmap admin_groupid --from-literal=group_id="{{ group_id }}" -n litmus
+          
+        - name: cluster connect
+          shell: python3 /api_testing/cluster/cluster-connect.py --cluster_name {{ cluster_name }} --provider {{ provider }} --url {{ director_url }} --username {{ username.stdout }} --password {{ password.stdout }}
+      
+        - name: Fetch connected cluster id
+          shell: python3 /api_testing/cluster/cluster-connect.py --cluster_name {{ cluster_name }} --provider {{ provider }} --url {{ director_url }} --username {{ username.stdout }} --password {{ password.stdout }}
+          register: cluster_id
+
+        - set_fact: 
+            cluster_id: "{{ cluster_id.stdout }}"
+
+        - name: Create configmap for admin_cluster_id 
+          shell: kubectl create configmap admin_clusterid --from-literal=cluster_id="{{ cluster_id }}" -n litmus
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/admin-cluster-connect/test.yaml
+++ b/litmus/director/admin-cluster-connect/test.yaml
@@ -35,7 +35,7 @@
             group_id: "{{ group_id.stdout }}"
 
         - name: Create configmap for admin_group_id 
-          shell: kubectl create configmap admin_groupid --from-literal=group_id="{{ group_id }}" -n litmus
+          shell: kubectl create configmap admin-groupid --from-literal=group_id="{{ group_id }}" -n litmus
           
         - name: cluster connect
           shell: python3 /api_testing/cluster/cluster-connect.py --cluster_name {{ cluster_name }} --provider {{ provider }} --url {{ director_url }} --username {{ username.stdout }} --password {{ password.stdout }}
@@ -48,7 +48,7 @@
             cluster_id: "{{ cluster_id.stdout }}"
 
         - name: Create configmap for admin_cluster_id 
-          shell: kubectl create configmap admin_clusterid --from-literal=cluster_id="{{ cluster_id }}" -n litmus
+          shell: kubectl create configmap admin-clusterid --from-literal=cluster_id="{{ cluster_id }}" -n litmus
 
         - set_fact:
             flag: "Pass"

--- a/litmus/director/admin-cluster-connect/test_vars.yml
+++ b/litmus/director/admin-cluster-connect/test_vars.yml
@@ -1,0 +1,6 @@
+test_name: cluster-connect
+director_client_namespace: "{{ lookup('env','DIRECTOR_CLIENT_NAMESPACE') }}"
+director_server_namespace: "{{ lookup('env','DIRECTOR_SERVER_NAMESPACE') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
+cluster_name: "{{ lookup('env','CLUSTER_NAME') }}"
+provider: "{{ lookup('env','PROVIDER') }}"


### PR DESCRIPTION
**Description:**
- This pr contains `admin-cluster-connect` job 
- This job will create configmap `admin-groupid` and `admin-clusterid` for self connect cluster.

**[Logs]**
[admin-job-logs.txt](https://github.com/mayadata-io/oep-e2e/files/4352827/admin-job-logs.txt)

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>
