### PR TITLE
add cluster account resources test cases

### DIFF
--- a/litmus/director/account-access/cluster-account/run_litmus_test.yml
+++ b/litmus/director/account-access/cluster-account/run_litmus_test.yml
@@ -31,9 +31,17 @@ spec:
               configMapKeyRef:
                 name: config
                 key: url
+          - name: WEB_PROTOCOL
+            value: http
+          - name: DIRECTOR_PORT
+            value: "30380"
+          - name: STS_NAMESPACE_LIST
+            value: ["app-mongo-ns"]
+          - name: DEPLOYMENT_NAMESPACE_LIST
+            value: ''
           - name: ANSIBLE_STDOUT_CALLBACK
             value: default  
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./litmus/director/account-access/test.yaml -i /etc/ansible/hosts -v; exit 0"]
+        args: ["-c", "ansible-playbook ./litmus/director/account-access/cluster-account/test.yaml -i /etc/ansible/hosts -v; exit 0"]
       imagePullSecrets:
       - name: oep-secret

--- a/litmus/director/account-access/cluster-account/run_litmus_test.yml
+++ b/litmus/director/account-access/cluster-account/run_litmus_test.yml
@@ -2,14 +2,14 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: account-resources-check
+  generateName: cluster-account-resources-check
   namespace: litmus
 spec:
   template:
     metadata:
       name: litmus
       labels:
-        app: account-resources-check-litmus
+        app: cluster-account-resources-check-litmus
     spec:
       serviceAccountName: litmus
       restartPolicy: Never

--- a/litmus/director/account-access/cluster-account/test.yaml
+++ b/litmus/director/account-access/cluster-account/test.yaml
@@ -17,7 +17,7 @@
             status: 'SOT'
 
         - set_fact:
-            director_url : "http://{{ director_ip }}:30380"
+            director_url : "{{ web_protocol }}://{{ director_ip }}:{{ director_port }}"
         
         - name: Get username
           shell: cat /etc/secret-volume/username
@@ -29,36 +29,40 @@
 
         - name: Fetch pool pods from cluster
           shell: kubectl get pods -n openebs | grep cstor | awk '{print $1}'
-          register: pool_pods
-
-        - name: Get cluster pool resources for ProjectAccount
-          shell: python3 /api_testing/group/access.py --username {{ username.stdout }} --password {{ password.stdout }} --account ProjectAccount --url {{ director_url }} --resource pool
-          register: projectacc_pool_pods_resources
-
-        - name: Get cluster application resources for ProjectAccount
-          shell: python3 /api_testing/group/access.py --username {{ username.stdout }} --password {{ password.stdout }} --account ProjectAccount --url {{ director_url }} --resource maya-app
-          register: projectacc_app_resources
-
+          register: cstor_pool_pods
+ 
         - name: Get cluster pool resources for ClusterAccount
           shell: python3 /api_testing/group/access.py --username {{ username.stdout }} --password {{ password.stdout }} --account ClusterAccount --url {{ director_url }} --resource pool
           register: clusteracc_pool_pods_resources
+
+        - name: Check if cluster pool pods is same as Cluster Account pool pod resources
+          shell: echo "pool pods list found on the cluster is same as director cluster account maya app resources"
+          failed_when: "cstor_pool_pods.stdout_lines != clusteracc_pool_pods_resources.stdout_lines"
 
         - name: Get cluster application resources for ClusterAccount
           shell: python3 /api_testing/group/access.py --username {{ username.stdout }} --password {{ password.stdout }} --account ClusterAccount --url {{ director_url }} --resource maya-app
           register: clusteracc_app_resources
 
-        - debug:
-            msg: pool pods list found on the cluster is same as provided by cluster account maya app resources
-          when: "pool_pods.stdout_lines == clusteracc_pool_pods_resources.stdout_lines"
+        - block:
 
-        - debug:
-            msg: "project account pool pods list is inclusive of cluster account pool pods list "
-          when: "clusteracc_pool_pods_resources.stdout_lines not in  projectacc_pool_pods_resources.stdout_lines"
-          
-        - debug:
-            msg: "project account maya apps list is inclusive of cluster account maya apps list "
-          when: "clusteracc_app_resources.stdout_lines not in  projectacc_app_resources.stdout_lines"
-          
+            - name: Fetch statefulset applications from cluster
+              shell: kubectl get sts -n {{ item }} --no-headers | awk '{print $1}'
+              register: sts
+              until: "sts.stdout in clusteracc_app_resources.stdout_lines"
+              with_items: "{{ sts_namespace_list }}"
+
+          when: "'' is not in sts_namespace_list"
+
+        - block:
+
+            - name: Fetch deployment applications from cluster
+              shell: kubectl get deployment -n {{ item }} --no-headers | awk '{print $1}'
+              register: deployment
+              until: "deployment.stdout in clusteracc_app_resources.stdout_lines"
+              with_items: "{{ deployment_namespace_list }}"
+
+          when: "'' is not in deployment_namespace_list"
+
         - set_fact:
             flag: "Pass"
 

--- a/litmus/director/account-access/cluster-account/test_vars.yml
+++ b/litmus/director/account-access/cluster-account/test_vars.yml
@@ -1,4 +1,4 @@
-test_name: account-resources-check
+test_name: cluster-account-resources-check
 director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
 web_protocol: "{{ lookup('env','WEB_PROTOCOL') }}"
 director_port: "{{ lookup('env','DIRECTOR_PORT') }}"

--- a/litmus/director/account-access/cluster-account/test_vars.yml
+++ b/litmus/director/account-access/cluster-account/test_vars.yml
@@ -1,0 +1,6 @@
+test_name: account-resources-check
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
+web_protocol: "{{ lookup('env','WEB_PROTOCOL') }}"
+director_port: "{{ lookup('env','DIRECTOR_PORT') }}"
+sts_namespace_list: "{{ lookup('env','STS_NAMESPACE_LIST') }}"
+deployment_namespace_list: "{{ lookup('env','DEPLOYMENT_NAMESPACE_LIST') }}"

--- a/litmus/director/account-access/test_vars.yml
+++ b/litmus/director/account-access/test_vars.yml
@@ -1,2 +1,0 @@
-test_name: account-resources-check
-director_ip: "{{ lookup('env','DIRECTOR_IP') }}"


### PR DESCRIPTION
Signed-off-by: harshita-sharma011 <harshita.sharma@mayadata.io>

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->
Test cases added:
- Inside a ClusterAccount you will get all cluster specific storage pools. 
-  Inside a ClusterAccount you will get all cluster specific applications.

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

-  `director-user-pass` secret is already created on the cluster
-  some sts or deployments are running on the cluster

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```
Logs: 
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
included: /ansible-utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /ansible-utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "9b17de1263078377b5457817149c992997beb218", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f159984f5d10c9b26f6a1a76cb5b848d", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1584607977.2310188-188687646030618/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.003244", "end": "2020-03-19 08:52:58.264955", "rc": 0, "start": "2020-03-19 08:52:58.261711", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: account-resources-check \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: account-resources-check ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.533722", "end": "2020-03-19 08:52:59.035260", "failed_when_result": false, "rc": 0, "start": "2020-03-19 08:52:58.501538", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/account-resources-check configured", "stdout_lines": ["litmusresult.litmus.io/account-resources-check configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"director_url": "http://34.74.102.61:30380"}, "changed": false}

TASK [Get username] ************************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /etc/secret-volume/username", "delta": "0:00:00.003299", "end": "2020-03-19 08:52:59.404193", "rc": 0, "start": "2020-03-19 08:52:59.400894", "stderr": "", "stderr_lines": [], "stdout": "866936543B7C8468E386", "stdout_lines": ["866936543B7C8468E386"]}

TASK [Get password] ************************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /etc/secret-volume/password", "delta": "0:00:00.003665", "end": "2020-03-19 08:52:59.664595", "rc": 0, "start": "2020-03-19 08:52:59.660930", "stderr": "", "stderr_lines": [], "stdout": "v2HDWEk5SwwoRDucQHFdDcmtK4sbppY6S9P2nv9E", "stdout_lines": ["v2HDWEk5SwwoRDucQHFdDcmtK4sbppY6S9P2nv9E"]}

TASK [Fetch pool pods from cluster] ********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs | grep cstor | awk '{print $1}'", "delta": "0:00:00.074044", "end": "2020-03-19 08:52:59.949423", "rc": 0, "start": "2020-03-19 08:52:59.875379", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-7chc-58466f479b-qnp4v\ncstor-sparse-pool-8hej-8cf4456f6-6ltc2\ncstor-sparse-pool-cs7n-7d884698ff-r9nps", "stdout_lines": ["cstor-sparse-pool-7chc-58466f479b-qnp4v", "cstor-sparse-pool-8hej-8cf4456f6-6ltc2", "cstor-sparse-pool-cs7n-7d884698ff-r9nps"]}

TASK [Get cluster pool resources for ClusterAccount] ***************************
changed: [127.0.0.1] => {"changed": true, "cmd": "python3 /api_testing/group/access.py --username 866936543B7C8468E386 --password v2HDWEk5SwwoRDucQHFdDcmtK4sbppY6S9P2nv9E --account ClusterAccount --url http://34.74.102.61:30380 --resource pool", "delta": "0:00:00.184224", "end": "2020-03-19 08:53:00.343530", "rc": 0, "start": "2020-03-19 08:53:00.159306", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-7chc-58466f479b-qnp4v\ncstor-sparse-pool-8hej-8cf4456f6-6ltc2\ncstor-sparse-pool-cs7n-7d884698ff-r9nps", "stdout_lines": ["cstor-sparse-pool-7chc-58466f479b-qnp4v", "cstor-sparse-pool-8hej-8cf4456f6-6ltc2", "cstor-sparse-pool-cs7n-7d884698ff-r9nps"]}

TASK [Check if cluster pool pods is same as Cluster Account pool pod resources] ***
changed: [127.0.0.1] => {"changed": true, "cmd": "echo \"pool pods list found on the cluster is same as director cluster account maya app resources\"", "delta": "0:00:00.003073", "end": "2020-03-19 08:53:00.592702", "failed_when_result": false, "rc": 0, "start": "2020-03-19 08:53:00.589629", "stderr": "", "stderr_lines": [], "stdout": "pool pods list found on the cluster is same as director cluster account maya app resources", "stdout_lines": ["pool pods list found on the cluster is same as director cluster account maya app resources"]}

TASK [Get cluster application resources for ClusterAccount] ********************
changed: [127.0.0.1] => {"changed": true, "cmd": "python3 /api_testing/group/access.py --username 866936543B7C8468E386 --password v2HDWEk5SwwoRDucQHFdDcmtK4sbppY6S9P2nv9E --account ClusterAccount --url http://34.74.102.61:30380 --resource maya-app", "delta": "0:00:00.161250", "end": "2020-03-19 08:53:00.989918", "rc": 0, "start": "2020-03-19 08:53:00.828668", "stderr": "", "stderr_lines": [], "stdout": "mongo", "stdout_lines": ["mongo"]}

TASK [Fetch statefulset applications from cluster] *****************************
changed: [127.0.0.1] => (item=app-mongo-ns) => {"ansible_loop_var": "item", "attempts": 1, "changed": true, "cmd": "kubectl get sts -n app-mongo-ns --no-headers | awk '{print $1}'", "delta": "0:00:00.072718", "end": "2020-03-19 08:53:01.283224", "item": "app-mongo-ns", "rc": 0, "start": "2020-03-19 08:53:01.210506", "stderr": "", "stderr_lines": [], "stdout": "mongo", "stdout_lines": ["mongo"]}

TASK [Fetch deployment applications from cluster] ******************************
skipping: [127.0.0.1] => (item=)  => {"ansible_loop_var": "item", "changed": false, "item": "", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /ansible-utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "e3729e5bd0348710d6a1c62702b2a4cf2a5652be", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "1d0e7871f83e12f56f24a4c00fc224e3", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1584607981.6297836-117926121854716/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.003179", "end": "2020-03-19 08:53:02.182698", "rc": 0, "start": "2020-03-19 08:53:02.179519", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: account-resources-check \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: account-resources-check ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.264660", "end": "2020-03-19 08:53:02.660446", "failed_when_result": false, "rc": 0, "start": "2020-03-19 08:53:02.395786", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/account-resources-check configured", "stdout_lines": ["litmusresult.litmus.io/account-resources-check configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=19   changed=13   unreachable=0    failed=0    skipped=9    rescued=0    ignored=0   
```


