### PR TITLE
create administrator secret for self-connected cluster

### DIFF
--- a/litmus/director/admin-create-apikey/run_litmus_test.yml
+++ b/litmus/director/admin-create-apikey/run_litmus_test.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: create-admininstator-secret-check
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: fetch-unique-id-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+          - name: ADMIN_USERNAME
+            value: Administrator
+          - name: ADMIN_PASSWORD
+            value: password 
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/admin-create-apikey/test.yaml -i /etc/ansible/hosts -v; exit 0"]
+      imagePullSecrets:
+      - name: oep-secret

--- a/litmus/director/admin-create-apikey/test.yaml
+++ b/litmus/director/admin-create-apikey/test.yaml
@@ -1,0 +1,58 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - set_fact:
+            director_url : "http://{{ director_ip }}:30380"
+        
+        - name : Admin login
+          uri:
+            url: "{{ director_url }}/v3/token"
+            method: POST
+            body_format: json
+            body:
+              {"code": "{{ admin_username }}:{{ admin_password }}", "authProvider": "localAuthConfig"}
+            status_code: 201
+          register: login
+
+        - set_fact: 
+            jwt: "{{ login.json.jwt }}"
+
+        - name: Creating new api key
+          shell: python3 /api_testing/api-key/api-key.py --url {{ director_url }} --token {{ jwt }}
+          register: credentials
+
+        - set_fact:
+            username: "{{ credentials.stdout_lines[0] }}"
+            password: "{{ credentials.stdout_lines[1] }}"
+
+        - name: Create a kubernetes secret 
+          shell: kubectl create secret generic director-admin-pass --from-literal=username={{ username }} --from-literal=password={{ password }} -n litmus
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/admin-create-apikey/test_vars.yml
+++ b/litmus/director/admin-create-apikey/test_vars.yml
@@ -1,0 +1,4 @@
+test_name: create-admininstator-secret-check
+admin_username: "{{ lookup('env','ADMIN_USERNAME') }}"
+admin_password: "{{ lookup('env','ADMIN_PASSWORD') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"


### PR DESCRIPTION
Signed-off-by: harshita-sharma011 <harshita.sharma@mayadata.io>

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```

Logs:
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
included: /ansible-utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /ansible-utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "fc3abb9f46824ee279301f6bfd801495d2ed3aa0", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "d3fbc17789c800abb47e07b4378da87c", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1584614596.890586-69594836444302/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.003420", "end": "2020-03-19 10:43:17.974143", "rc": 0, "start": "2020-03-19 10:43:17.970723", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-admininstator-secret-check \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-admininstator-secret-check ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.478155", "end": "2020-03-19 10:43:18.693127", "failed_when_result": false, "rc": 0, "start": "2020-03-19 10:43:18.214972", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-admininstator-secret-check configured", "stdout_lines": ["litmusresult.litmus.io/create-admininstator-secret-check configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"director_url": "http://34.74.102.61:30380"}, "changed": false}

TASK [Admin login] *************************************************************
ok: [127.0.0.1] => {"changed": false, "connection": "close", "content_length": "436", "content_type": "application/json; charset=utf-8", "cookies": {"PL": "DirectorOnline"}, "cookies_string": "PL=DirectorOnline", "date": "Thu, 19 Mar 2020 10:43:19 GMT", "elapsed": 0, "expires": "Thu, 01 Jan 1970 00:00:00 GMT", "json": {"accountId": "1a9", "actions": {}, "authProvider": "localAuthConfig", "baseType": "token", "code": null, "enabled": true, "id": null, "inviteCode": null, "jwt": "gnunLE4YS2ngFm54ESafiYUTEv54T5J1eZwu356c", "links": {"remove": null}, "projectInvitationCode": null, "redirectUrl": null, "security": true, "slackOauthUrl": "https://slack.com/oauth/authorize?client_id=&scope=bot,incoming-webhook,commands", "type": "token", "user": "Administrator", "userType": "admin"}, "msg": "OK (436 bytes)", "redirected": false, "server": "nginx/1.13.12", "set_cookie": "PL=DirectorOnline;Path=/", "status": 201, "url": "http://34.74.102.61:30380/v3/token", "x_api_account_id": "1a4", "x_api_client_ip": "10.142.0.4", "x_api_roles": "token", "x_api_schemas": "http://34.74.102.61:30380/v3/schemas", "x_api_user_id": "1a4"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"jwt": "gnunLE4YS2ngFm54ESafiYUTEv54T5J1eZwu356c"}, "changed": false}

TASK [Creating new api key] ****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "python3 /api_testing/api-key/api-key.py --url http://34.74.102.61:30380 --token gnunLE4YS2ngFm54ESafiYUTEv54T5J1eZwu356c", "delta": "0:00:00.194102", "end": "2020-03-19 10:43:19.918574", "rc": 0, "start": "2020-03-19 10:43:19.724472", "stderr": "", "stderr_lines": [], "stdout": "6EFE9FB764A35A9B5517\n4fVzjR3DUVmqMEwTT1oBQMguqgUgH9SVnUKDo3XV", "stdout_lines": ["6EFE9FB764A35A9B5517", "4fVzjR3DUVmqMEwTT1oBQMguqgUgH9SVnUKDo3XV"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"password": "4fVzjR3DUVmqMEwTT1oBQMguqgUgH9SVnUKDo3XV", "username": "6EFE9FB764A35A9B5517"}, "changed": false}

TASK [Create a kubernetes secret] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create secret generic director-admin-pass --from-literal=username=6EFE9FB764A35A9B5517 --from-literal=password=4fVzjR3DUVmqMEwTT1oBQMguqgUgH9SVnUKDo3XV -n litmus", "delta": "0:00:00.105601", "end": "2020-03-19 10:43:20.282736", "rc": 0, "start": "2020-03-19 10:43:20.177135", "stderr": "", "stderr_lines": [], "stdout": "secret/director-admin-pass created", "stdout_lines": ["secret/director-admin-pass created"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /ansible-utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "61bc1837ddf4607b7f6bc5d89bc7efad1fda24f5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5f26bf9930533e30d3d30a68fd75a1b1", "mode": "0644", "owner": "root", "size": 430, "src": "/root/.ansible/tmp/ansible-tmp-1584614600.630009-275758242480704/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.003586", "end": "2020-03-19 10:43:21.185660", "rc": 0, "start": "2020-03-19 10:43:21.182074", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-admininstator-secret-check \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-admininstator-secret-check ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.213040", "end": "2020-03-19 10:43:21.668187", "failed_when_result": false, "rc": 0, "start": "2020-03-19 10:43:21.455147", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-admininstator-secret-check configured", "stdout_lines": ["litmusresult.litmus.io/create-admininstator-secret-check configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=17   changed=8    unreachable=0    failed=0    skipped=8    rescued=0    ignored=0  
```

