### PR TITLE
adding project account resources access

### DIFF
--- a/litmus/director/account-access/project-account/run_litmus_test.yml
+++ b/litmus/director/account-access/project-account/run_litmus_test.yml
@@ -2,14 +2,14 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: account-resources-check
+  generateName: project-account-resources-check
   namespace: litmus
 spec:
   template:
     metadata:
       name: litmus
       labels:
-        app: account-resources-check-litmus
+        app: project-account-resources-check-litmus
     spec:
       serviceAccountName: litmus
       restartPolicy: Never
@@ -31,9 +31,17 @@ spec:
               configMapKeyRef:
                 name: config
                 key: url
+          - name: WEB_PROTOCOL
+            value: http
+          - name: DIRECTOR_PORT
+            value: "30380"
+          - name: STS_NAMESPACE_LIST
+            value: '["app-mongo-ns"]'
+          - name: DEPLOYMENT_NAMESPACE_LIST
+            value: ''
           - name: ANSIBLE_STDOUT_CALLBACK
             value: default  
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./litmus/director/account-access/test.yaml -i /etc/ansible/hosts -v; exit 0"]
+        args: ["-c", "ansible-playbook ./litmus/director/account-access/project-account/test.yaml -i /etc/ansible/hosts -v; exit 0"]
       imagePullSecrets:
       - name: oep-secret

--- a/litmus/director/account-access/project-account/test.yaml
+++ b/litmus/director/account-access/project-account/test.yaml
@@ -17,7 +17,7 @@
             status: 'SOT'
 
         - set_fact:
-            director_url : "http://{{ director_ip }}:30380"
+            director_url : "{{ web_protocol }}://{{ director_ip }}:{{ director_port }}"
         
         - name: Get username
           shell: cat /etc/secret-volume/username
@@ -29,7 +29,7 @@
 
         - name: Fetch pool pods from cluster
           shell: kubectl get pods -n openebs | grep cstor | awk '{print $1}'
-          register: pool_pods
+          register: cstor_pool_pods
 
         - name: Get cluster pool resources for ProjectAccount
           shell: python3 /api_testing/group/access.py --username {{ username.stdout }} --password {{ password.stdout }} --account ProjectAccount --url {{ director_url }} --resource pool
@@ -39,26 +39,30 @@
           shell: python3 /api_testing/group/access.py --username {{ username.stdout }} --password {{ password.stdout }} --account ProjectAccount --url {{ director_url }} --resource maya-app
           register: projectacc_app_resources
 
-        - name: Get cluster pool resources for ClusterAccount
-          shell: python3 /api_testing/group/access.py --username {{ username.stdout }} --password {{ password.stdout }} --account ClusterAccount --url {{ director_url }} --resource pool
-          register: clusteracc_pool_pods_resources
+        - name: Check if cluster pool pods is same as Project Account pool pod resources
+          shell: echo "pool pods list found on the cluster is same as director project account pool pods resources"
+          failed_when: "cstor_pool_pods.stdout_lines != projectacc_pool_pods_resources.stdout_lines"
 
-        - name: Get cluster application resources for ClusterAccount
-          shell: python3 /api_testing/group/access.py --username {{ username.stdout }} --password {{ password.stdout }} --account ClusterAccount --url {{ director_url }} --resource maya-app
-          register: clusteracc_app_resources
+        - block:
 
-        - debug:
-            msg: pool pods list found on the cluster is same as provided by cluster account maya app resources
-          when: "pool_pods.stdout_lines == clusteracc_pool_pods_resources.stdout_lines"
+            - name: Fetch statefulset applications from cluster
+              shell: kubectl get sts -n {{ item }} --no-headers | awk '{print $1}'
+              register: sts
+              until: "sts.stdout in projectacc_app_resources.stdout_lines"
+              with_items: "{{ sts_namespace_list }}"
 
-        - debug:
-            msg: "project account pool pods list is inclusive of cluster account pool pods list "
-          when: "clusteracc_pool_pods_resources.stdout_lines not in  projectacc_pool_pods_resources.stdout_lines"
-          
-        - debug:
-            msg: "project account maya apps list is inclusive of cluster account maya apps list "
-          when: "clusteracc_app_resources.stdout_lines not in  projectacc_app_resources.stdout_lines"
-          
+          when: "'' is not in sts_namespace_list"
+
+        - block:
+
+            - name: Fetch deployment applications from cluster
+              shell: kubectl get deployment -n {{ item }} --no-headers | awk '{print $1}'
+              register: deployment
+              until: "deployment.stdout in projectacc_app_resources.stdout_lines"
+              with_items: "{{ deployment_namespace_list }}"
+
+          when: "'' is not in deployment_namespace_list"
+
         - set_fact:
             flag: "Pass"
 

--- a/litmus/director/account-access/project-account/test_vars.yml
+++ b/litmus/director/account-access/project-account/test_vars.yml
@@ -1,0 +1,6 @@
+test_name: project-account-resources-check
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
+web_protocol: "{{ lookup('env','WEB_PROTOCOL') }}"
+director_port: "{{ lookup('env','DIRECTOR_PORT') }}"
+sts_namespace_list: "{{ lookup('env','STS_NAMESPACE_LIST') }}"
+deployment_namespace_list: "{{ lookup('env','DEPLOYMENT_NAMESPACE_LIST') }}"

--- a/litmus/director/account-access/test_vars.yml
+++ b/litmus/director/account-access/test_vars.yml
@@ -1,2 +1,0 @@
-test_name: account-resources-check
-director_ip: "{{ lookup('env','DIRECTOR_IP') }}"


### PR DESCRIPTION
Signed-off-by: harshita-sharma011 <harshita.sharma@mayadata.io>

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->
Test cases added:

- Inside a ProjectAccount you will get all clusters applications.
- Inside a ProjectAccount you will get all clusters storage pools. 

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->
-  `director-user-pass` secret is already created on the cluster
-  some sts or deployments are running on the cluster


#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```
Logs:
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
included: /ansible-utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /ansible-utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "9a51831374f64739a451d0775e4085542a0df3b7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "eab7e975decf4cd66190b0b013299775", "mode": "0644", "owner": "root", "size": 430, "src": "/root/.ansible/tmp/ansible-tmp-1584657375.2821045-166231036878860/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.004436", "end": "2020-03-19 22:36:16.298938", "rc": 0, "start": "2020-03-19 22:36:16.294502", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: project-account-resources-check \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: project-account-resources-check ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.416200", "end": "2020-03-19 22:36:16.925838", "failed_when_result": false, "rc": 0, "start": "2020-03-19 22:36:16.509638", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/project-account-resources-check configured", "stdout_lines": ["litmusresult.litmus.io/project-account-resources-check configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"director_url": "http://35.237.220.153:30380"}, "changed": false}

TASK [Get username] ************************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /etc/secret-volume/username", "delta": "0:00:00.002959", "end": "2020-03-19 22:36:17.335930", "rc": 0, "start": "2020-03-19 22:36:17.332971", "stderr": "", "stderr_lines": [], "stdout": "DCEF255D1CBE7C899FC2", "stdout_lines": ["DCEF255D1CBE7C899FC2"]}

TASK [Get password] ************************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /etc/secret-volume/password", "delta": "0:00:00.003044", "end": "2020-03-19 22:36:17.538921", "rc": 0, "start": "2020-03-19 22:36:17.535877", "stderr": "", "stderr_lines": [], "stdout": "3y2b3ysFvRqu5z6VXUDXtqxjyQ7yjhMkhLKfTnvS", "stdout_lines": ["3y2b3ysFvRqu5z6VXUDXtqxjyQ7yjhMkhLKfTnvS"]}

TASK [Fetch pool pods from cluster] ********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs | grep cstor | awk '{print $1}'", "delta": "0:00:00.073955", "end": "2020-03-19 22:36:17.823474", "rc": 0, "start": "2020-03-19 22:36:17.749519", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-i2rt-576b79f77-tg4x8\ncstor-sparse-pool-vji4-7cc79f4b9c-85c6z\ncstor-sparse-pool-zua6-6959d84649-fzn8n", "stdout_lines": ["cstor-sparse-pool-i2rt-576b79f77-tg4x8", "cstor-sparse-pool-vji4-7cc79f4b9c-85c6z", "cstor-sparse-pool-zua6-6959d84649-fzn8n"]}

TASK [Get cluster pool resources for ProjectAccount] ***************************
changed: [127.0.0.1] => {"changed": true, "cmd": "python3 /api_testing/group/access.py --username DCEF255D1CBE7C899FC2 --password 3y2b3ysFvRqu5z6VXUDXtqxjyQ7yjhMkhLKfTnvS --account ProjectAccount --url http://35.237.220.153:30380 --resource pool", "delta": "0:00:00.230418", "end": "2020-03-19 22:36:18.266069", "rc": 0, "start": "2020-03-19 22:36:18.035651", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-i2rt-576b79f77-tg4x8\ncstor-sparse-pool-vji4-7cc79f4b9c-85c6z\ncstor-sparse-pool-zua6-6959d84649-fzn8n", "stdout_lines": ["cstor-sparse-pool-i2rt-576b79f77-tg4x8", "cstor-sparse-pool-vji4-7cc79f4b9c-85c6z", "cstor-sparse-pool-zua6-6959d84649-fzn8n"]}

TASK [Get cluster application resources for ProjectAccount] ********************
changed: [127.0.0.1] => {"changed": true, "cmd": "python3 /api_testing/group/access.py --username DCEF255D1CBE7C899FC2 --password 3y2b3ysFvRqu5z6VXUDXtqxjyQ7yjhMkhLKfTnvS --account ProjectAccount --url http://35.237.220.153:30380 --resource maya-app", "delta": "0:00:00.167352", "end": "2020-03-19 22:36:18.646222", "rc": 0, "start": "2020-03-19 22:36:18.478870", "stderr": "", "stderr_lines": [], "stdout": "mongo", "stdout_lines": ["mongo"]}

TASK [Check if cluster pool pods is same as Project Account pool pod resources] ***
changed: [127.0.0.1] => {"changed": true, "cmd": "echo \"pool pods list found on the cluster is same as director project account pool pods resources\"", "delta": "0:00:00.002754", "end": "2020-03-19 22:36:18.848963", "failed_when_result": false, "rc": 0, "start": "2020-03-19 22:36:18.846209", "stderr": "", "stderr_lines": [], "stdout": "pool pods list found on the cluster is same as director project account pool pods resources", "stdout_lines": ["pool pods list found on the cluster is same as director project account pool pods resources"]}

TASK [Fetch statefulset applications from cluster] *****************************
changed: [127.0.0.1] => (item=app-mongo-ns) => {"ansible_loop_var": "item", "attempts": 1, "changed": true, "cmd": "kubectl get sts -n app-mongo-ns --no-headers | awk '{print $1}'", "delta": "0:00:00.099717", "end": "2020-03-19 22:36:19.202387", "item": "app-mongo-ns", "rc": 0, "start": "2020-03-19 22:36:19.102670", "stderr": "", "stderr_lines": [], "stdout": "mongo", "stdout_lines": ["mongo"]}

TASK [Fetch deployment applications from cluster] ******************************
skipping: [127.0.0.1] => (item=)  => {"ansible_loop_var": "item", "changed": false, "item": "", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /ansible-utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "b332b11a40bc15e85b3593c4f26481a84f0c3ac0", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "80369ad7dcad5304e04153805f731541", "mode": "0644", "owner": "root", "size": 428, "src": "/root/.ansible/tmp/ansible-tmp-1584657379.5231578-281039215641021/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.003450", "end": "2020-03-19 22:36:20.055407", "rc": 0, "start": "2020-03-19 22:36:20.051957", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: project-account-resources-check \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: project-account-resources-check ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.149529", "end": "2020-03-19 22:36:20.464894", "failed_when_result": false, "rc": 0, "start": "2020-03-19 22:36:20.315365", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/project-account-resources-check configured", "stdout_lines": ["litmusresult.litmus.io/project-account-resources-check configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=19   changed=13   unreachable=0    failed=0    skipped=9    rescued=0    ignored=0 
```