### PR TITLE
(fix):Fetch cluster_id from configmap admin-clusterid and group_id from configmap admin-groupid

### DIFF
--- a/litmus/director/tcid-iuoi01-openebs-self-install/run_litmus_test.yml
+++ b/litmus/director/tcid-iuoi01-openebs-self-install/run_litmus_test.yml
@@ -34,18 +34,18 @@ spec:
                 name: config
                 key: url
 
-          ## Take cluster_id from configmap clusterid
+          ## Take cluster_id from configmap admin-clusterid
           - name: CLUSTER_ID    
             valueFrom:
               configMapKeyRef:
-                name: clusterid
+                name: admin-clusterid
                 key: cluster_id
 
-          ## Takes group_id from configmap groupid
+          ## Takes group_id from configmap admin-groupid
           - name: GROUP_ID
             valueFrom:
               configMapKeyRef:
-                name: groupid
+                name: admin-groupid
                 key: group_id
 
           ## It should be 1ot1 Mandatory

--- a/litmus/director/tcid-iuoi01-openebs-self-install/test.yml
+++ b/litmus/director/tcid-iuoi01-openebs-self-install/test.yml
@@ -46,14 +46,6 @@
           register: openebs_namespace
           when: "count_maya_api.stdout == '1'"
 
-        ## Removing the labels from the cluster nodes
-        - include_tasks: /utils/openebs-label-cleanup.yml
-
-        ## Deleting openebs from the cluster
-        - include_tasks: /utils/openebs-cleanup.yml
-          vars:
-            namespace: "{{ openebs_namespace.stdout }}"
-
         ## Fetch the projectid of the project where the cluster is running
         - name: Fetch the project details of the project where the cluster is running
           uri:
@@ -70,6 +62,20 @@
         - name: Saving the project id
           set_fact:
             project_id: "{{ project_details.json.data[0].id }}"
+
+        ## Getting the total number of nodes in the cluster
+        - name: Getting the number of nodes in the cluster
+          shell: kubectl get nodes --no-headers | wc -l
+          args:
+            executable: /bin/bash
+          register: nodes
+
+        ## Fail the test if it contains less than two nodes
+        ## Minimum two nodes required
+        - name: Checking if the cluster contains atleast two nodes
+          fail:
+            msg: Minimum two nodes is required to install openebs in this cluster
+          when: "{{ nodes.stdout }} < 2"
 
         ## Getting node details of the cluster
         ## Selecting the node which is in active state present in the cluster
@@ -95,6 +101,14 @@
           set_fact:
             node_id: "{{ node_id  + [item.id] }}"
           loop: "{{ node_details.json.data }}"
+
+         ## Removing the labels from the cluster nodes
+        - include_tasks: /utils/openebs-label-cleanup.yml
+
+        ## Deleting openebs from the cluster
+        - include_tasks: /utils/openebs-cleanup.yml
+          vars:
+            namespace: "{{ openebs_namespace.stdout }}"
 
 
         ## Labeling the node-1 of the Cluster with controlPlaneNode=true and dataPlaneNode=true

--- a/litmus/director/tcid-iuoi01-openebs-self-install/test.yml
+++ b/litmus/director/tcid-iuoi01-openebs-self-install/test.yml
@@ -71,20 +71,6 @@
           set_fact:
             project_id: "{{ project_details.json.data[0].id }}"
 
-        ## Getting the total number of nodes in the cluster
-        - name: Getting the number of nodes in the cluster
-          shell: kubectl get nodes --no-headers | wc -l
-          args:
-            executable: /bin/bash
-          register: nodes
-
-        ## Fail the test if it contains less than two nodes
-        ## Minimum two nodes required
-        - name: Checking if the cluster contains atleast two nodes
-          fail:
-            msg: Minimum two nodes is required to install openebs in this cluster
-          when: "{{ nodes.stdout }} < 2"
-
         ## Getting node details of the cluster
         ## Selecting the node which is in active state present in the cluster
         - name: Getting the node details of the cluster


### PR DESCRIPTION


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```



