### PR TITLE
(tcid-rec01):List capacity recommendations

### DIFF
--- a/litmus/director/tcid-rec01-list-recommendations/run_litmus_test.yml
+++ b/litmus/director/tcid-rec01-list-recommendations/run_litmus_test.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: list-recommendations-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: list-recommendations
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci 
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+
+          ## Takes director-ip from configmap director-ip
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Takes group-id from configmap group-id
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          - name: NAMESPACE
+            value: ''
+
+          ## Takes cluster_id from configmap
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/tcid-rec01-list-recommendations/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      imagePullSecrets:
+      - name: oep-secret   

--- a/litmus/director/tcid-rec01-list-recommendations/test.yml
+++ b/litmus/director/tcid-rec01-list-recommendations/test.yml
@@ -1,0 +1,145 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        - set_fact:
+            director_url : "http://{{ director_ip }}:30380"
+
+        ## Getting the username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting the password.stdout     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        ## Check whether openebs components are in Running state or not
+        - name: Check whether openebs components are in Running state or not
+          shell: kubectl get pods -n {{ namespace }}  | grep {{ item }} | awk '{print $3}' | awk -F':' '{print $1}' | tail -n 1
+          register: app_status
+          until: app_status.stdout == 'Running'
+          with_items:
+            - "{{ openebs_components }}"
+          retries: 20
+          delay: 5
+
+        ## Get application pool health status for replica-1
+        - name: Get application pool health status for replica-1
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[0].data.pods[0].state=='Running'"
+          retries: 20
+          delay: 2
+        
+        ## Get application pool health status for replica-2
+        - name: Get application pool health status for replica-2
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[1].data.pods[0].state=='Running'"
+          retries: 20
+          delay: 2
+
+        ## Get application pool health status for replica-3
+        - name: Get application pool health status for replica-3
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[2].data.pods[0].state=='Running'"
+          retries: 20
+          delay: 2
+        
+        ## Fetch the recommendation details
+        - name: Fetch recommendations details
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/recommendations"
+            method: GET
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 200
+          register: recommendations
+        
+        ## Fetch the recommendation id 
+        - name: Fetch the recommendation id
+          set_fact:
+            recommendation_id: "{{ recommendations.json.data[0].id }}"
+
+        ## List Recommendations
+        - name: List Recommendations
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/{{ recommendation_id }}/?action=getcapacityrecommendation'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            body: '{"clusterId":"{{ cluster_id }}", "raidGroupConfig":{"groupDeviceCount":1, "type":"stripe"}}'
+            status_code: 201
+          register: recommendation_list
+        
+        ## List capacity recommendation
+        - name: List capacity recommendation
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/recommendations/{{ recommendation_id }}"
+            method: GET
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 200
+          register: capacity_recommendation
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CRhttps://github.com/mayadata-io/oep-e2e-gcp/blob/dc8f3585e5debe12a700220066b204a0b35cbb5c/stages/9-openebs-install-check/openebs-reinstallation.md)
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/tcid-rec01-list-recommendations/test_vars.yml
+++ b/litmus/director/tcid-rec01-list-recommendations/test_vars.yml
@@ -1,0 +1,15 @@
+
+test_name: list-recommendations
+openebs_components:
+  [
+    'openebs-provisioner',
+    'openebs-ndm-operator',
+    'openebs-ndm',
+    'openebs-snapshot-operator',
+    'openebs-admission-server',
+    'openebs-localpv-provisioner',
+    'maya-apiserver',
+  ]
+group_id: "{{ lookup('env','GROUP_ID') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

- List recommendation and capacity recommendations.

**_Details:_**

**_Steps involved in openebs update in cluster:_**

- **Pre-checks**: 
  - Check whether all the openebs components are in running state or not.
  - Check whether application pools are in running state or not.

- **Steps involved in the test case**
  -  First get the recommendation details by **GET** request on url: `url: "{{ director_url }}/v3/groups/{{ group_id }}/recommendations"`
  - Now you will get the `recommendation_id`
  - By the help of this `recommendation_id` **POST** request on url `'{{ director_url }}/v3/groups/{{ group_id }}/{{ recommendation_id }}/?action=getcapacityrecommendation'` by this GET request you will get list of recommendations

       - **Body of POST request**
         `body: '{"clusterId":"{{ cluster_id }}", "raidGroupConfig":{"groupDeviceCount":1, "type":"stripe"}}'` 

- At last after hitting GET request on `"{{ director_url }}/v3/groups/{{ group_id }}/recommendations/{{ recommendation_id }}` we will get `capacity recommendations`


**Additional Information-** 

| Title | Description |
| --- | --- |
|Assumptions | openebs should be already installed with version less then 1.7.0 |
|| cStor pools should be available and should be in running state|
|| 3 Node cluster |
| Application Under Test | Openebs Pool upgrade using DOP when all pool pods are not running |
| Stogare Engine | cStor |
|Application Used|MongoDB Statefulset|
| Openebs Version | 1.9.0 |

**Notes to reviewer**