### PR TITLE
(FIX):Changed secret name for self-connect cluster and removed openesb clean-up task

### DIFF
--- a/litmus/director/tcid-iuoi01-openebs-self-install/run_litmus_test.yml
+++ b/litmus/director/tcid-iuoi01-openebs-self-install/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       volumes:
       - name: secret-volume
         secret:
-          secretName: director-user-pass
+          secretName: director-admin-pass
       containers:
       - name: ansibletest
         image: mayadataio/dop-validator:ci

--- a/litmus/director/tcid-iuoi01-openebs-self-install/test.yml
+++ b/litmus/director/tcid-iuoi01-openebs-self-install/test.yml
@@ -102,15 +102,6 @@
             node_id: "{{ node_id  + [item.id] }}"
           loop: "{{ node_details.json.data }}"
 
-         ## Removing the labels from the cluster nodes
-        - include_tasks: /utils/openebs-label-cleanup.yml
-
-        ## Deleting openebs from the cluster
-        - include_tasks: /utils/openebs-cleanup.yml
-          vars:
-            namespace: "{{ openebs_namespace.stdout }}"
-
-
         ## Labeling the node-1 of the Cluster with controlPlaneNode=true and dataPlaneNode=true
         ## With first element in the node_id list
         - name: Labeling the node-1 of the cluster

--- a/litmus/director/tcid-iuoi01-openebs-self-install/test.yml
+++ b/litmus/director/tcid-iuoi01-openebs-self-install/test.yml
@@ -203,12 +203,6 @@
           retries: 20
           delay: 2         
 
-        ## Removing the labels from the cluster nodes
-        - include_tasks: /utils/openebs-label-cleanup.yml
-
-        ## Deleting openebs from the cluster
-        - include_tasks: /utils/openebs-cleanup.yml
-
         - set_fact:
             flag: "Pass"
 


### PR DESCRIPTION
- Changed secret name from `director-user-pass` to `director-admin-pass`
- And also removed clean-up of openebs because in self install cluster we are not installing openebs.

**Special Note For Reviewer:** 

**[REFER FOR SECRET]** https://github.com/mayadata-io/oep-e2e/pull/289/files

