### PR TITLE
(Bug):Passing namespace to the openebs-cleanup.yml

### DIFF
--- a/litmus/director/tcid-iuoi02-openebs-install/test.yml
+++ b/litmus/director/tcid-iuoi02-openebs-install/test.yml
@@ -251,6 +251,8 @@
 
         ## Deleting openebs from the cluster
         - include_tasks: /utils/openebs-cleanup.yml
+          vars:
+            namespace: "{{ openebs_namespace.stdout }}"
     
         ## Setting flag as Pass
         - set_fact:


### PR DESCRIPTION
- Passing namespace to the openebs-cleanup.yml at the last of the job to remove openebs.
Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>



