### PR TITLE
fix path for director-url

### DIFF
--- a/litmus/director/maya-io-server/test.yaml
+++ b/litmus/director/maya-io-server/test.yaml
@@ -30,7 +30,7 @@
           delay: 10
         
         - name: Fetch director url
-          shell: cat /etc/director-url
+          shell: cat /etc/director-url/url
           register: node_ip
 
         - set_fact:


### PR DESCRIPTION
This PR fixes the path to read the director-url which is being used in getting it's value.

Signed-off-by: Shivesh Abhishek <shankeyshivesh@gmail.com>