### PR TITLE
[tcid-iuoc02]Upgrade OpenEBS installed using operator.yaml(Not using Director)

### DIFF
--- a/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/README.md
+++ b/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/README.md
@@ -1,0 +1,79 @@
+# Upgrade OpenEBS installed using operator.yaml(Not using Director)
+
+---
+tcid: iuoc02
+name: "Upgrade OpenEBS installed using operator.yaml(Not using Director)"
+
+---
+------
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th> Description </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> Openebs Installation </td>
+    <td> Upgrade OpenEBS installed using operator.yaml(Not using Director) </td>
+    <td> GKE </td>
+  </tr>
+</table>
+
+## Prerequisites
+
+- Along with k8s, Litmus should be installed in the cluster.
+- Every component of DOP cluster should be healthy and running.
+- Ensure that the openebs is already installed in the cluster.
+
+## Details
+
+- Upgrade OpenEBS installed using operator.yaml(Not using Director)
+
+### Expected output
+
+- OpenEBS ControlPlane upgrade should not proceed because openebs is installed using operator.yml in cluster.
+
+## Steps Performed in the test
+
+- Check whether OpenEBS is installed in the cluster or not.
+
+- Also check the status of all the `Data-Plane` and `Control-Plane` components they should be in `running` state.
+
+- Get active openebs record from  `v3/groups/{gropu_id}/cluster/{cluster_id}/openebs/{openebs_id}`
+
+- After that trigger action `upgradecontrolplane`. Once we triggered the action with the target version as input.
+
+- This should result into a `InvalidAction`
+
+- Control plane upgrade should not proceed.
+
+
+## Integrations
+
+- This test can be performed on GKE cluster where DOP is installed.
+- The desired specification for installing openebs in DOP cluster can be done by passing the values from `run_litmus_tes.yml`. And then we have to select the `installation mode` which can have two different modes `basic` and `advance`. For installing openebs with default values use `basic` mode and for installing openebs with the desired value it will be `advance`.
+
+## Steps to Execute the test manually 
+
+- Use `run_litmus_test.yml` with the your `image` (contains the image of the experiment) , `secret`(contains the userid and password), `configmaps`(contains dop url and cluster id) files and other environment variables.
+- Create `run_litmus_test.yml` file in `litmus` namespace. 
+- Check the test log using `kubectl logs -f <jobs-pod-name> -n <litmus>` command.
+
+
+### Watch Test progress
+
+- View the test progress  
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+### Check Test Result
+
+- Check whether the test is Pass or Fail using the following command
+ 
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+- Check the Pass and Fail value at the end of test logs.
+- The pod will be in the `completed` state.

--- a/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/run_litmus_test.yml
+++ b/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/run_litmus_test.yml
@@ -1,0 +1,67 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: control-plane-upgrade-operator-yml-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: control-plane-upgrade-operator-yml-
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci 
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+
+          ## Takes director-ip from configmap director-ip
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Takes group-id from configmap group-id
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          - name: NAMESPACE
+            value: 'openebs'
+     
+          - name: OPENEBS_TARGET_VERSION
+            value: 1.8.0
+          
+          - name: OPENEBS_CURRENT_VERSION
+            value: 1.7.0
+
+          ## Takes cluster_id from configmap
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/tcid-iuoc02-control-plane-upgrade-operator.yml/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      imagePullSecrets:
+      - name: oep-secret   

--- a/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/test.yml
+++ b/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/test.yml
@@ -1,0 +1,106 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+  
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        - set_fact:
+            director_url : "http://{{ director_ip }}:30380"
+
+        ## Getting the username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting the password.stdout     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+        
+        ## Installing openebs
+        - include_tasks: /utils/install-openebs.yml
+
+        ## Check whether openebs components are in Running state or not
+        - name: Fetch OpenEBS control plane pods state
+          shell: kubectl get pods -n {{ namespace }}  | grep {{ item }} | awk '{print $3}' | awk -F':' '{print $1}' | tail -n 1
+          register: app_status
+          until: app_status.stdout == 'Running'
+          with_items:
+            - "{{ openebs_components }}"
+          retries: 30
+          delay: 10
+
+        ## Get the container Status of the openebs pods
+        - name: Get the container status of the openebs pods.
+          shell: >
+            kubectl get pod -n {{ namespace }} --no-headers
+            -o jsonpath='{.items[*].status.containerStatuses[*].ready}' | tr ' ' '\n' | uniq
+          args:
+            executable: /bin/bash
+          register: containerStatus
+          until: "containerStatus.stdout == 'true'"
+          retries: 30
+          delay: 10        
+        
+        ## Get active openebses
+        - name: Get active openebses
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/openebses?state=active&clusterId={{ cluster_id}}"
+            method: GET
+            url_username: "{{ username.stdout }}" 
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 200
+          register: openebses_active
+          failed_when: openebses_active.json.data == []
+
+        ## Getting the openebses id
+        - name: Getting the openebses id
+          set_fact:
+            openebs_id: "{{ openebses_active.json.data[0].id }}"
+        
+        ## Trying to upgrade openebs control plane components
+        - name: Trying to upgrade openebs control plane components
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/openebses/{{ openebs_id }}/?action=upgradecontrolplane"
+            method: POST
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            body: '{"upgradeVersion":"{{ openebs_target_version }}"}'
+            status_code: 422
+          register: openebs_upgrade
+
+        ## Deleting openebs from the cluster
+        - include_tasks: /utils/openebs-cleanup.yml
+
+        - set_fact:
+            flag: "Pass"
+        
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/test.yml
+++ b/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/test.yml
@@ -16,9 +16,6 @@
         - include_tasks: /ansible-utils/update_litmus_result_resource.yml
           vars:
             status: 'SOT'
-          
-        - set_fact:
-            director_url : "http://{{ director_ip }}:30380"
 
         ## Getting the username
         - name: Get username

--- a/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/test_vars.yml
+++ b/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/test_vars.yml
@@ -1,0 +1,17 @@
+test_name: control-plane-upgrade-operator-yml
+openebs_target_version: "{{ lookup('env','OPENEBS_TARGET_VERSION') }}"
+openebs_current_version: "{{ lookup('env','OPENEBS_CURRENT_VERSION') }}"
+openebs_components:
+  [
+    'openebs-provisioner',
+    'openebs-ndm-operator',
+    'openebs-ndm',
+    'openebs-snapshot-operator',
+    'openebs-admission-server',
+    'openebs-localpv-provisioner',
+    'maya-apiserver',
+  ]
+namespace: "{{ lookup('env','NAMESPACE') }}"
+group_id: "{{ lookup('env','GROUP_ID') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"

--- a/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/test_vars.yml
+++ b/litmus/director/tcid-iuoc02-control-plane-upgrade-operator-yml/test_vars.yml
@@ -14,4 +14,4 @@ openebs_components:
 namespace: "{{ lookup('env','NAMESPACE') }}"
 group_id: "{{ lookup('env','GROUP_ID') }}"
 cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
-director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
+director_url: "{{ lookup('env','DIRECTOR_IP') }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Upgrade OpenEBS installed using operator.yaml(Not using Director) 

**_Details:_**

**_Steps involved:_**

- **Pre-checks**: 

- Check whether all the openebs components are in running state or not.
- Also check the status of all the Data-Plane and Control-Plane components they should be in running state.

**Steps involved in the test case**

- Get active openebs record from v3/groups/{gropu_id}/cluster/{cluster_id}/openebs/{openebs_id}

- After that trigger action upgradecontrolplane. Once we triggered the action with the target version as input.
- This should result into a `InvalidAction`
- Control plane upgrade should not proceed.
  
**Additional Information-** 

| Title | Description |
| --- | --- |
|Assumptions | openebs should be already installed with version less then 1.8.0 |
|| All control plane components in running state|
|| 3 Node cluster |
| Application Under Test | Upgrade OpenEBS installed using operator.yaml(Not using Director) |
| Stogare Engine | -|
|Application Used|-|
| Openebs Version | 1.8.0 |

**Notes to reviewer**

-


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>

