### PR TITLE
[tcid-iuod25]Upgrade the application with 3 replicas when two pool pods are in pending state

### DIFF
--- a/litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/README.md
+++ b/litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/README.md
@@ -1,0 +1,76 @@
+# Upgrade the application with 3 replicas when two pool pods are not running
+
+<b>tcid:</b> iuod25 <br>
+<b>name:</b> "Upgrade the application with 3 replicas when two pool pods are not running" <br>
+
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th> Description </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> Install and Upgrade of OpenEBS </td>
+    <td> Upgrade the application with 3 replicas when two pool pods are not running </td>
+    <td> GKE </td>
+  </tr>
+</table>
+
+## Prerequisites
+
+- Along with k8s, Litmus should be installed in the cluster.
+- Every component of DOP cluster should be healthy and running.
+- Ensure that the `openebs data plane and control plane components` are available in the cluster.
+
+
+## Details
+- In this test case we have to upgrade only the `Data Plane` components using DOP when one pool pod is not in running state.
+
+
+- `Data Plane` components should not get upgraded because two pool pod is not in running state.
+
+## Steps Performed in the test
+
+- Check whether OpenEBS is installed in the cluster or not.
+
+- Also check the status of all the `Data-Plane` and `Control-Plane` components they should be in `running` state.
+
+- Version of OpenEBS should be less then 1.7.0 .
+
+- First upgrade `Control-Plane` components, check whether all the components are in running state or not.
+
+- Now create some scenario so that two application pool pod should go in pending state .
+
+- After sending all application volume replica pod to pending state try to upgrade `Data Plane` components using DOP.
+
+- Upgrade of `Data Plane` components through DOP should get failed .
+
+
+## Integrations
+
+- This test can be performed on GKE cluster where the openebs is already installed and the version of openebs should be less the 1.7.0.
+
+## Steps to Execute the test manually 
+
+- Use `run_litmus_test.yml` with the your `image` (contains the image of the experiment) , `secret`(contains the userid and password), `configmaps`(contains dop url and cluster id) files and other environment variables.
+- Create `run_litmus_test.yml` file in `litmus` namespace. 
+- Check the test log using `kubectl logs -f <jobs-pod-name> -n <litmus>` command.
+
+
+### Watch Test progress
+
+- View the test progress  
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+### Check Test Result
+
+- Check whether the test is Pass or Fail using the following command
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+- Check the Pass and Fail value at the end of test logs.
+- The pod will be in the `completed` state.

--- a/litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/run_litmus_test.yml
+++ b/litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/run_litmus_test.yml
@@ -1,0 +1,64 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: pool-upgrade-two-pod-not-running-check
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: pool-upgrade-two-pod-not-running
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci 
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+
+          ## Takes director-ip from configmap director-ip
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Takes group-id from configmap group-id
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          - name: NAMESPACE
+            value: 'openebs'
+     
+          - name: OPENEBS_TARGET_VERSION
+            value: 1.8.0
+
+          ## Takes cluster_id from configmap
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      imagePullSecrets:
+      - name: oep-secret   

--- a/litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/test.yml
+++ b/litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/test.yml
@@ -1,0 +1,212 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+  
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        ## Getting the username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting the password.stdout     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        ## Check whether openebs components are in Running state or not
+        - name: Check whether openebs components are in Running state or not
+          shell: kubectl get pods -n {{ namespace }}  | grep {{ item }} | awk '{print $3}' | awk -F':' '{print $1}' | tail -n 1
+          register: app_status
+          until: app_status.stdout == 'Running'
+          with_items:
+            - "{{ openebs_components }}"
+          retries: 20
+          delay: 5
+
+        ## Get application pool health status for replica-1
+        - name: Get application pool health status for replica-1
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[0].data.pods[0].state=='Running'"
+          retries: 20
+          delay: 2
+        
+        ## Get application pool health status for replica-2
+        - name: Get application pool health status for replica-2
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[1].data.pods[0].state=='Running'"
+          retries: 20
+          delay: 2
+
+        ## Get application pool health status for replica-3
+        - name: Get application pool health status for replica-3
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[2].data.pods[0].state=='Running'"
+          retries: 20
+          delay: 2
+        
+        # Fetch name of cstor-disk-pool deployment 
+        - name: Name of cstor-disk-pool
+          shell: kubectl get deploy -l {{ pool_label }} -n {{ namespace }} -o jsonpath='{.items[0].metadata.name}'
+          register: deployment_name
+        
+        # Replacing the image of deployment so that the pools pods will go in pending state
+        - name: Change image to some dummy value 
+          shell: kubectl set image deployment/{{ deployment_name.stdout }} cstor-pool={{ dummy_image }} -n {{ namespace }}
+
+        # Check the state of the pool pod
+        - name: Check the state of pool pod
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[0].data.pods[0].state=='Pending'"
+          retries: 30
+          delay: 5
+        
+        # Fetch name of cstor-disk-pool deployment 2
+        - name: Name of cstor-disk-pool
+          shell: kubectl get deploy -l {{ pool_label }} -n {{ namespace }} -o jsonpath='{.items[1].metadata.name}'
+          register: deployment_name2
+        
+        # Replacing the image of deployment 2 so that the pools pods will go in pending state
+        - name: Change image to some dummy value 
+          shell: kubectl set image deployment/{{ deployment_name2.stdout }} cstor-pool={{ dummy_image }} -n {{ namespace }}
+
+        # Check the state of the pool pod
+        - name: Check the state of pool pod
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[1].data.pods[0].state=='Pending'"
+          retries: 30
+          delay: 5
+
+        ## Get storage pool details
+        - name: Get application details
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: storage_pools
+        
+        ## Upgrade data-plane component
+        - name: Upgrade data-plane component
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/openebsupgradeclaims'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            body: '{"clusterId":"{{ cluster_id }}","kind":"poolUpgrade","targetVersion":"{{ openebs_target_version }}","upgradeComponents":[{"id":"{{ storage_pools.json.data[0].id }}"},{"id":"{{ storage_pools.json.data[1].id }}"},{"id":"{{ storage_pools.json.data[2].id }}"}]}'
+            status_code: 405
+          register: upgrade_claim
+        
+        # Rollout the changes performed in deployment 1
+        - name: Rollout the changes performed in deployment
+          shell: kubectl rollout undo deploy/{{deployment_name.stdout}} -n {{ namespace }}
+        
+        # wait untill pod comes in running state
+        - name: Wait untill the pod comes in running state
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[0].data.pods[0].state=='Running'"
+          retries: 30
+          delay: 5
+
+        # Rollout the changes performed in deployment 2
+        - name: Rollout the changes performed in deployment
+          shell: kubectl rollout undo deploy/{{deployment_name2.stdout}} -n {{ namespace }}
+        
+        # wait untill pod comes in running state
+        - name: Wait untill the pod comes in running state
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayastoragepools'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: pool_health
+          until: "pool_health.json.data[1].data.pods[0].state=='Running'"
+          retries: 30
+          delay: 5
+        
+        ## Setting flag as pass 
+        - set_fact:
+              flag: 'Pass'
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: 'Fail'
+    
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+
+        

--- a/litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/test_vars.yml
+++ b/litmus/director/tcid-iuod25-pool-upgrade-two-pod-not-running/test_vars.yml
@@ -1,0 +1,19 @@
+test_name: pool-upgrade-two-pod-not-running-check
+openebs_target_version: "{{ lookup('env','OPENEBS_TARGET_VERSION') }}"
+openebs_components:
+  [
+    'openebs-provisioner',
+    'openebs-ndm-operator',
+    'openebs-ndm',
+    'openebs-snapshot-operator',
+    'openebs-admission-server',
+    'openebs-localpv-provisioner',
+    'maya-apiserver',
+  ]
+namespace: "{{ lookup('env','NAMESPACE') }}"
+group_id: "{{ lookup('env','GROUP_ID') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+director_url: "{{ lookup('env','DIRECTOR_IP') }}"
+pool_label: "app=cstor-pool"
+dummy_image: "dummy_image:123"
+app_ns: app-mongo-ns


### PR DESCRIPTION
**What this PR does / why we need it**:

- Upgrade the pools  when two pool pods are not running.

**_Details:_**

**_Steps involved in openebs update in cluster:_**

- **Installing openebes**: 
  - Check whether all the openebs components are in running state or not.
  - Check whether application pools are in running state or not.

- **Steps involved in the test case**
  -  To send one application pool replica to pending state just change the image of the deployment.
  - Now replica pod will go into `pending` state.
  - After pod went to pending state try to upgrade control plane components.
  - It should give error code `405` and the test case will pass when it gives response status code `405`

**Additional Information-** 

| Title | Description |
| --- | --- |
|Assumptions | openebs should be already installed with version less then 1.7.0 |
|| cStor pools should be available and should be in running state|
|| 3 Node cluster |
| Application Under Test | Openebs Pool upgrade using DOP when all pool pods are not running |
| Stogare Engine | cStor |
|Application Used|MongoDB Statefulset|
| Openebs Version | Version upgrade to 1.7.0 |

**Notes to reviewer**

- This is the negative test case where we have to upgarde pools when one of the pool pods are not in running state it should give some error.
- Dependent PRs -


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>

