### PR TITLE
Increase time for checking cluster active state

### DIFF
--- a/api_testing/cluster/cluster.py
+++ b/api_testing/cluster/cluster.py
@@ -93,7 +93,7 @@ class Cluster():
             os.system(yamlApply)
             print(f"Cluster {self.nameInit} is connecting...")
             # wait for cluster to be Active
-            timer = 3
+            timer = 5
             total_time = 0
             while not self.isActive():
                 if total_time >= 60:

--- a/api_testing/cluster/cluster.py
+++ b/api_testing/cluster/cluster.py
@@ -93,10 +93,10 @@ class Cluster():
             os.system(yamlApply)
             print(f"Cluster {self.nameInit} is connecting...")
             # wait for cluster to be Active
-            timer = 5
+            timer = 3
             total_time = 0
             while not self.isActive():
-                if total_time >= 60:
+                if total_time >= 180:
                     print("Cluster is not getting Active. Something is wrong")
                     sys.exit(1)
                 time.sleep(timer)


### PR DESCRIPTION
Signed-off-by: Harsh Shekhar <harshshekhar15@gmail.com>

This PR intends to increase the time for which the connected cluster state is checked.

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```



