### PR TITLE
Make job url generic for all platforms in result table

### DIFF
--- a/utils/result_update.py
+++ b/utils/result_update.py
@@ -52,7 +52,7 @@ content_list = file_content.split('\n')
 file_update_retries = 5
 
 # github job log url using job_id
-job_url ="<a href= \"https://gitlab.mayadata.io/oep/oep-e2e-gcp/-/jobs/{0}\">{0}</a>".format(job_id)
+job_url ="<a href= \"https://gitlab.mayadata.io/oep/oep-e2e-{0}/-/jobs/{1}\">{1}</a>".format(platform,job_id)
 
 def fetch_file_content():
     # fetching file contents of github file_path readme.md


### PR DESCRIPTION
Signed-off-by: Harsh Shekhar <harshshekhar15@gmail.com>

This PR intends to fix job URL in result table.
<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```



