### PR TITLE
Removed openebs cleanup task from openebs-resource-limit-installation job

### DIFF
--- a/litmus/director/tcid-iuoi14-openebs-resource-limit-installation/test.yml
+++ b/litmus/director/tcid-iuoi14-openebs-resource-limit-installation/test.yml
@@ -184,30 +184,7 @@
             executable: /bin/bash
           register: memory_limit
           failed_when: "memory_limit.stdout != memory_resource_limit"
-
-        ## Checking if openebs is installed or not.
-        - name: Check if openebs is installed or not.
-          shell: kubectl get deploy --all-namespaces -l name=maya-apiserver --no-headers | awk '{print $1}' | wc -l
-          args:
-            executable: /bin/bash
-          register: count_maya_api
-
-        ## If openebs is installed in the cluster then get the namespace
-        - name: Getting the namespace where openebs is installed 
-          shell: kubectl get deploy --all-namespaces -l name=maya-apiserver --no-headers | awk '{print $1}'
-          args:
-            executable: /bin/bash
-          register: openebs_namespace
-          when: "count_maya_api.stdout == '1'"
-
-        ## Removing the labels from the cluster nodes
-        - include_tasks: /utils/openebs-label-cleanup.yml
-
-        ## Deleting openebs from the cluster
-        - include_tasks: /utils/openebs-cleanup.yml
-          vars:
-            namespace: "{{ openebs_namespace.stdout }}"          
-
+          
         - set_fact:
             flag: "Pass"
 


### PR DESCRIPTION

- Removed openebs cleanup task from openebs-resource-limit-installation job

- We removed openebs clean-up from this job because we need to use openebs for creating cstorpools in cluster3


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>




