### PR TITLE
Increase no of retries for checking cluster state

### DIFF
--- a/api_testing/cluster/cluster.py
+++ b/api_testing/cluster/cluster.py
@@ -96,7 +96,7 @@ class Cluster():
             timer = 3
             total_time = 0
             while not self.isActive():
-                if total_time >= 180:
+                if total_time >= 300:
                     print("Cluster is not getting Active. Something is wrong")
                     sys.exit(1)
                 time.sleep(timer)


### PR DESCRIPTION
Signed-off-by: Harsh Shekhar <harshshekhar15@gmail.com>
 
This PR intends to increase retries for checking connected cluster state. The retry time needs to be increased further as the cluster connect is taking some more tiime for on premise clusters.

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```



