### PR TITLE
[TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ]:Verify creation of raidz cstor pool

### DIFF
--- a/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/README.md
+++ b/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/README.md
@@ -1,0 +1,69 @@
+# Verify creation of raidz cstor pool cluster
+
+<b>tcid:</b> TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ <br>
+<b>name:</b> "Verify creation of raidz cstor pool cluster"<br>
+
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th> Description </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> Cstor Pool Recommendation </td>
+    <td> Verify creation of raidz cstor pool cluster </td>
+    <td> GKE </td>
+  </tr>
+</table>
+
+## Prerequisites
+
+- Along with k8s, Litmus should be installed in the cluster.
+- Every component of DOP cluster should be healthy and running.
+- Ensure that the `openebs data plane and control plane components` are available in the cluster.
+
+## Details
+
+- Director version 1.9 onwards
+- Positive test case
+
+## Steps Performed in the test
+
+- Invoke API to list recommendations
+- Invoke API to get capacity based recommendations
+- Invoke API to get device based recommendations
+- Invoke API to get raidz based cstor pool recommendations
+- Invoke API to create raidz cstor pool cluster
+
+### Expected output
+
+- Director should be able to create raidz cstor pool cluster
+
+## Integrations
+
+- This test can be performed on GKE cluster where the openebs is already installed and the version of openebs should be less the 1.7.0.
+
+## Steps to Execute the test manually 
+
+- Use `run_litmus_test.yml` with the your `image` (contains the image of the experiment) , `secret`(contains the userid and password), `configmaps`(contains dop url and cluster id) files and other environment variables.
+- Create `run_litmus_test.yml` file in `litmus` namespace. 
+- Check the test log using `kubectl logs -f <jobs-pod-name> -n <litmus>` command.
+
+
+### Watch Test progress
+
+- View the test progress  
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+### Check Test Result
+
+- Check whether the test is Pass or Fail using the following command
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+- Check the Pass and Fail value at the end of test logs.
+- The pod will be in the `completed` state.

--- a/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/run_litmus_test.yml
+++ b/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/run_litmus_test.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: create-cstor-pool-raidz-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: create-cstor-pool-raidz
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci 
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+
+          ## Takes director-ip from configmap director-ip
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Takes group-id from configmap group-id
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          - name: NAMESPACE
+            value: 'openebs'
+
+          ## Takes cluster_id from configmap
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      imagePullSecrets:
+      - name: oep-secret   

--- a/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/test.yml
+++ b/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/test.yml
@@ -1,0 +1,156 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        ## Getting the username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting the password.stdout     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        ## Check whether openebs components are in Running state or not
+        - name: Check whether openebs components are in Running state or not
+          shell: kubectl get pods -n {{ namespace }}  | grep {{ item }} | awk '{print $3}' | awk -F':' '{print $1}' | tail -n 1
+          register: app_status
+          until: app_status.stdout == 'Running'
+          with_items:
+            - "{{ openebs_components }}"
+          retries: 20
+          delay: 5
+
+        - name: Get BD
+          shell: | 
+            kubectl get bd -n {{ namespace }}
+
+        ## Fetch the recommendation details
+        - name: Fetch recommendations details
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/recommendations"
+            method: GET
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 200,201,202
+          register: recommendations
+        
+        ## Fetch the recommendation id 
+        - name: Fetch the recommendation id
+          set_fact:
+            recommendation_id: "{{ recommendations.json.data[0].id }}"
+
+        ## List Capacity Recommendations
+        - name: List Capacity Recommendations
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/recommendations/{{ recommendation_id }}/?action=getcapacityrecommendation'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            body: '{"clusterId":"{{ cluster_id }}", "raidGroupConfig":{"groupDeviceCount":3, "raidType":"raidz"}}'
+            status_code: 200,201,202
+          register: recommendation_list
+
+        ## Fetch the deviceGroupName
+        - name: Fetch the deviceGroupName
+          set_fact:
+            device_groupName: "{{ recommendation_list.json.data[0].deviceGroupName }}"
+
+        ## List Device Recommendations
+        - name: List Device Recommendations
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/recommendations/{{ recommendation_id }}/?action=getdevicerecommendation'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            body: '{"clusterId":"{{ cluster_id }}", "deviceGroupName":"{{ device_groupName }}","poolCapacity":"1G","poolName":"rec-create-raidz", "raidGroupConfig":{"groupDeviceCount":3, "raidType":"raidz"}}'
+            status_code: 200,201,202
+          register: device_recommendation
+
+        ## Create cstorPoolOperation
+        - name: create cstorpooloperation
+          uri: 
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/cstorpooloperations'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            body: '{"clusterId":"{{ cluster_id }}", "input":{{ device_recommendation.json.data[0] | to_json | string | to_json }}, "kind":"CreateCStorPoolCluster"}'
+            status_code: 200,201,202
+          register: cstorpooloperation
+
+        ## Fetching cstorpooloperation id
+        - name: Fetching cstorpooloperation id
+          set_fact:
+            cstorpooloperation_id: "{{ cstorpooloperation.json.id }}"
+
+        ## Execute CStorPoolOpetation
+        - name: Execute CStorPoolOpetation
+          uri: 
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/cstorpooloperations/{{ cstorpooloperation_id }}/?action=execute'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            body: '{}'
+            status_code: 200,201,202
+          register: cstorpooloperation
+        
+        ## Wait for cstorpooloperation to get completed
+        - name: Wait for cstorpooloperation to get completed
+          uri: 
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/cstorpooloperations/{{ cstorpooloperation_id }}'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            status_code: 200,201,202
+          register: cstorpooloperation_state
+          until: "cstorpooloperation_state.json.state == 'success'"
+          delay: 10
+          retries: 40
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/test_vars.yml
+++ b/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/test_vars.yml
@@ -1,0 +1,15 @@
+test_name: create-cstor-pool-raidz
+openebs_components:
+  [
+    'openebs-provisioner',
+    'openebs-ndm-operator',
+    'openebs-ndm',
+    'openebs-snapshot-operator',
+    'openebs-admission-server',
+    'openebs-localpv-provisioner',
+    'maya-apiserver',
+  ]
+group_id: "{{ lookup('env','GROUP_ID') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+director_url: "{{ lookup('env','DIRECTOR_IP') }}"
+namespace: "{{ lookup('env','NAMESPACE') }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Verify creation of raidz cstor pool cluster

**_Details:_**

**_Steps involved in openebs update in cluster:_**

- **Pre-checks**: 
  - Check whether all the openebs components are in running state or not.
  - Check whether application pools are in running state or not.

- **Steps involved in the test case**
  -  First get the recommendation details by **GET** request on url: `url: "{{ director_url }}/v3/groups/{{ group_id }}/recommendations"`
  - Now you will get the `recommendation_id`
  - By the help of this `recommendation_id` **POST** request on url `'{{ director_url }}/v3/groups/{{ group_id }}/{{ recommendation_id }}/?action=getcapacityrecommendation'` by this GET request you will get list of recommendations

       - **Body of POST request**
         `body: '{"clusterId":"{{ cluster_id }}", "raidGroupConfig":{"groupDeviceCount":3, "type":"raidz"}}'` 

- Now after hitting GET request on `"{{ director_url }}/v3/groups/{{ group_id }}/recommendations/{{ recommendation_id }}` we will get `capacity recommendations`

- After getting device recommendation fetch the json data and POST request on {director-url}/v3/groups/1a{group-id}/recommendations/cstorpooloperations

- At last give POST request on {director-url}/v3/groups/1a{group-id}/cstorpooloperations/1cpo{cstorpooloperation-id}/?action=execute to execute CStorPoolOpetation

#### Expected output:
- Director should create raidz based cstor pool recommendations


**Additional Information-** 

| Title | Description |
| --- | --- |
|Assumptions | openebs should be already installed|
|| cStor pools should be available and should be in running state|
|| 3 Node cluster |
| Application Under Test | Openebs Pool upgrade using DOP when all pool pods are not running |
| Stogare Engine | cStor |
|Application Used|MongoDB Statefulset|
| Openebs Version | 1.9.0 |

**Notes to reviewer**




