### PR TITLE
Labeled all nodes as dataplane true for openebs resource limit test case

### DIFF
--- a/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE/test.yml
+++ b/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE/test.yml
@@ -107,6 +107,14 @@
           set_fact:
             node2_id: "{{ node_id[1].split('n')[1] }}"
 
+        - name: Get the node3_id
+          set_fact:
+            node3_id: "{{ node_id[2].split('n')[1] }}"
+
+        - name: Get the node4_id
+          set_fact:
+            node4_id: "{{ node_id[3].split('n')[1] }}"
+
         - name: Labeling the nodes of the cluster
           uri:
             url: "{{ director_url }}/v3/groups/{{ group_id }}/openebses/{{ openebsid }}/?action=selectopenebsnodes"
@@ -116,7 +124,7 @@
             force_basic_auth: yes
             return_content: yes
             body_format: json
-            body: '{"controlPlaneNodes":["{{node1_id}}"], "dataPlaneNodes":["{{node2_id}}"]}'
+            body: '{"controlPlaneNodes":["{{node1_id}}"], "dataPlaneNodes":["{{node1_id}}","{{node2_id}}","{{node3_id}}","{{node4_id}}"]}'
             status_code: 200
           register: labelnodes
 


### PR DESCRIPTION
- Labeled all the node as dataplane true in openebs resource limit test case.

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>


