### PR TITLE
[TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME]Delete CSPC not created via director which has no volume

### DIFF
--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/README.md
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/README.md
@@ -1,0 +1,85 @@
+# Delete CSPC not created via director which has no volume
+
+<b>tcid:</b> TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME <br>
+<b>name:</b> "Delete CSPC not created via director which has no volume"<br>
+
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th> Description </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> Cstor Pool Recommendation </td>
+    <td> Delete CSPC not created via director which has no volume </td>
+    <td> GKE </td>
+  </tr>
+</table>
+
+## Prerequisites
+
+- Along with k8s, Litmus should be installed in the cluster.
+- Every component of DOP cluster should be healthy and running.
+- Ensure that the `openebs data plane and control plane components` are available in the cluster.
+
+## Details
+
+- This test cases is to create cstor pool using cspc yaml and delete it using director.
+
+### Expected output
+
+- Delete CSPC created via director which has no volume
+
+## Steps Performed in the test
+
+- Check whether OpenEBS is installed in the cluster or not.
+
+- Also check the status of all the `Data-Plane` and `Control-Plane` components they should be in `running` state.
+
+- First get the recommendation details by GET request on  `url: "{{ director_url }}/v3/groups/{{ group_id }}/recommendations"`
+
+- Now you will get the `recommendation_id `
+
+- After this, by the help of this recommendation_id POST request on  `url :'{{ director_url }}/v3/groups/{{ group_id }}/{{ recommendation_id }}/?action=getdevicerecommendation'`  by this POST request you will get list of device recommendations
+
+- BODY OF REQUEST
+
+    `'{"clusterId":"{{ cluster_id }}", "deviceGroupName": null,"poolCapacity":"1G","poolName":null, "raidGroupConfig":{"groupDeviceCount":1, "type":"stripe"}}'`
+
+- After getting device recommendation fetch the json data and POST request on ` {director-url}/v3/groups/1a{group-id}/recommendations/cstorpooloperations`
+
+- At last give POST request on `{director-url}/v3/groups/1a{group-id}/cstorpooloperations/1cpo{cstorpooloperation-id}/?action=execute` to execute CStorPoolOpetation
+
+- Now wait until CStorPoolOpetation's state become success.
+
+- After this delete the cspc using director.
+
+
+## Integrations
+
+- This test can be performed on GKE cluster where the openebs is already installed and the version of openebs should be less the 1.7.0.
+
+## Steps to Execute the test manually 
+
+- Use `run_litmus_test.yml` with the your `image` (contains the image of the experiment) , `secret`(contains the userid and password), `configmaps`(contains dop url and cluster id) files and other environment variables.
+- Create `run_litmus_test.yml` file in `litmus` namespace. 
+- Check the test log using `kubectl logs -f <jobs-pod-name> -n <litmus>` command.
+
+
+### Watch Test progress
+
+- View the test progress  
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+### Check Test Result
+
+- Check whether the test is Pass or Fail using the following command
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+- Check the Pass and Fail value at the end of test logs.
+- The pod will be in the `completed` state.

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/run_litmus_test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/run_litmus_test.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: delete-cspc-external-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: delete-cspc-external
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci 
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+
+          ## Takes director-ip from configmap director-ip
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Takes group-id from configmap group-id
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          - name: NAMESPACE
+            value: 'openebs'
+
+          ## Takes cluster_id from configmap
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      imagePullSecrets:
+      - name: oep-secret   

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test.yml
@@ -1,0 +1,109 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        ## Getting the username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting the password.stdout     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        - name: Get BD
+          shell: | 
+            kubectl get bd -n {{ namespace }}
+
+        ## Get node name
+        - name: Get node name
+          shell: kubectl get node --no-headers | grep Ready | awk '{print $1}' | tail -n 1
+          register: node_name
+
+        ## Add bd name in cspc yml
+        - name: Add bd name in cspc yml
+          shell: sed -i "s/nodeName/{{node_name.stdout}}/g" /utils/cspc.yml 
+
+        ## Create cstorPoolOperation
+        - name: Get blockdevice 
+          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $1}' | tail -n 1
+          register: blockdevice_name
+        
+        ## Add bd name in cspc yml
+        - name: Add bd name in cspc yml
+          shell: sed -i "s/dummyvalue/{{blockdevice_name.stdout}}/g" /utils/cspc.yml
+        
+        ## Create CSPC
+        - name: Create CSPC 
+          shell: kubectl apply -f /utils/cspc.yml
+
+        - pause: 
+            seconds: 20
+
+        ## Delete CSPC using director
+        - name: Delete CSPC using director
+          uri: 
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/cstorpooloperations'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            headers:
+                Content-Type: "application/json"
+            body: '{"clusterId":"{{ cluster_id }}", "input":{"name":"cspc-external","kind":"CStorPoolCluster","version":"v1"}, "kind":"DeleteCStorPoolCluster"}'
+            status_code: 200,201,202
+          register: cspc_deletion
+
+        ## Fetching cstorpooloperation id
+        - name: Fetching cstorpooloperation id
+          set_fact:
+            cstorpooloperation_id: "{{ cspc_deletion.json.id }}"
+        
+        ## Wait for cstorpooloperation to get completed
+        - name: Wait for cstorpooloperation to get completed
+          uri: 
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/cstorpooloperations/{{ cstorpooloperation_id }}'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            status_code: 200,201,202
+          register: cstorpooloperation_state
+          until: "cstorpooloperation_state.json.state == 'success'"
+          delay: 10
+          retries: 40
+
+        ## Setting flag as Pass
+        - set_fact:
+            flag: "Pass"
+        
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test_vars.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test_vars.yml
@@ -1,0 +1,15 @@
+test_name: delete-cspc-external
+openebs_components:
+  [
+    'openebs-provisioner',
+    'openebs-ndm-operator',
+    'openebs-ndm',
+    'openebs-snapshot-operator',
+    'openebs-admission-server',
+    'openebs-localpv-provisioner',
+    'maya-apiserver',
+  ]
+group_id: "{{ lookup('env','GROUP_ID') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+director_url: "{{ lookup('env','DIRECTOR_IP') }}"
+namespace: "{{ lookup('env','NAMESPACE') }}"

--- a/utils/cspc.yml
+++ b/utils/cspc.yml
@@ -1,0 +1,13 @@
+apiVersion: cstor.openebs.io/v1
+kind: CStorPoolCluster
+metadata:
+  name: cspc-external
+spec:
+  pools:
+    - nodeSelector:
+        kubernetes.io/hostname: "nodeName"
+      dataRaidGroups:
+      - blockDevices:
+          - blockDeviceName: "dummyvalue"
+      poolConfig:
+        dataRaidGroupType: "stripe"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Delete CSPC not created via director which has no volume 

**_Details:_**

**_Steps involved in openebs update in cluster:_**

- **Pre-checks**: 
  - Check whether all the openebs components are in running state or not.
  - DOP should be installed


- **Steps involved in the test case**
  - Create CSPC using yaml
  - Invoke API to delete CSPC
  - Delete CSPC via director
  
#### Expected output:
- Director should delete the cspc


**Additional Information-** 

| Title | Description |
| --- | --- |
|Assumptions | openebs should be already installed|
||Dop Installed |
| Application Under Test | Delete CSPC not created via director which has no volume   |
| Stogare Engine |  |
|Application Used| |
| Openebs Version | 1.10.0 |

**Notes to reviewer*




