### PR TITLE
[TCID-DIR-OP-DELETE-SPC-WITH-VOLUME]:Delete SPC via director which has volume

### DIFF
--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/README.md
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/README.md
@@ -1,0 +1,73 @@
+# Delete SPC via director which has volume
+
+<b>tcid:</b> TCID-DIR-OP-DELETE-SPC-WITH-VOLUME <br>
+<b>name:</b> "Delete SPC via director which has volume"<br>
+
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th> Description </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> Cstor Pool Recommendation </td>
+    <td> Delete SPC via director which has volume </td>
+    <td> GKE </td>
+  </tr>
+</table>
+
+## Prerequisites
+
+- Along with k8s, Litmus should be installed in the cluster.
+- Every component of DOP cluster should be healthy and running.
+- Ensure that the `openebs data plane and control plane components` are available in the cluster.
+
+## Details
+
+- This test cases is to delete SPC pool using recommendations which has volume.
+
+### Expected output
+
+- Delete SPC via director which has volume
+
+## Steps Performed in the test
+
+- Check whether OpenEBS is installed in the cluster or not.
+
+- Also check the status of all the `Data-Plane` and `Control-Plane` components they should be in `running` state.
+
+- Create SPC using yaml.
+
+- Invoke API to delete SPC using director
+
+- Pools will not be deleted because it is used by some application.
+
+
+## Integrations
+
+- This test can be performed on GKE cluster where the openebs is already installed and the version of openebs should be less the 1.7.0.
+
+## Steps to Execute the test manually 
+
+- Use `run_litmus_test.yml` with the your `image` (contains the image of the experiment) , `secret`(contains the userid and password), `configmaps`(contains dop url and cluster id) files and other environment variables.
+- Create `run_litmus_test.yml` file in `litmus` namespace. 
+- Check the test log using `kubectl logs -f <jobs-pod-name> -n <litmus>` command.
+
+
+### Watch Test progress
+
+- View the test progress  
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+### Check Test Result
+
+- Check whether the test is Pass or Fail using the following command
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+- Check the Pass and Fail value at the end of test logs.
+- The pod will be in the `completed` state.

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/run_litmus_test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/run_litmus_test.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: delete-spc-with-volume-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: delete-spc-with-volume
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci 
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+
+          ## Takes director-ip from configmap director-ip
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Takes group-id from configmap group-id
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          - name: NAMESPACE
+            value: 'openebs'
+
+          ## Takes cluster_id from configmap
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      imagePullSecrets:
+      - name: oep-secret

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest/minio-official.yaml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest/minio-official.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio-deploy
+  namespace: delete-spc
+  labels:
+    name: minio
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: minio
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        name: minio
+    spec:
+      # Refer to the PVC created earlier
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          # Name of the PVC created earlier
+                claimName: minio-claim
+      # nodeSelector:
+      #   kubernetes.io/os: linux
+      containers:
+      - name: minio
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio
+        args:
+        - server
+        - /storage
+        env:
+        # Minio access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+        # Mount the volume into the pod
+        volumeMounts:
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest/minio-official.yaml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest/minio-official.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
-  name: minio-deploy
+  name: minio-deploy-spc
   namespace: delete-spc
   labels:
     name: minio

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest/minio-pvc.yaml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest/minio-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-claim
+  namespace: delete-spc
+  labels:
+    app: minio-storage-claim
+spec:
+  storageClassName: cstor-storageclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 15G

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest/minio-svc.yaml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest/minio-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-svc
+  namespace: delete-spc
+  labels:
+    name: minio
+spec:
+  ports:
+    - port: 9000
+      nodePort: 32701
+      protocol: TCP
+  selector:
+    name: minio
+  sessionAffinity: None
+  type: NodePort
+

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/sc.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/sc.yml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: cstor-storageclass
+provisioner: cstor.csi.openebs.io
+allowVolumeExpansion: true
+parameters:
+  cas-type: cstor
+  cstorPoolCluster: spc-volume
+  replicaCount: "1"

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/spc.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/spc.yml
@@ -1,0 +1,23 @@
+#Use the following YAMLs to create a SPC.
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: spc-volume
+  namespace: openebs
+  annotations:
+    cas.openebs.io/config: |
+      - name: PoolResourceRequests
+        value: |-
+            memory: 2Gi
+      - name: PoolResourceLimits
+        value: |-
+            memory: 4Gi
+spec:
+  name: cstor-disk-pools
+  type: disk
+  poolSpec:
+    poolType: striped
+  blockDevices:
+    blockDeviceList:
+    - dummyvalue
+    

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test.yml
@@ -1,0 +1,97 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        ## Getting the username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting the password.stdout     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        - name: Get BD
+          shell: | 
+            kubectl get bd -n {{ namespace }}
+
+        ## Create cstorPoolOperation
+        - name: Get blockdevice 
+          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $1}' | tail -n 1
+          register: blockdevice_name
+        
+        ## Add bd name in spc yml
+        - name: Add bd name in spc yml
+          shell: sed -i "s/dummyvalue/{{blockdevice_name.stdout}}/g" /litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/spc.yml
+
+        ## Create SPC
+        - name: Create SPC 
+          shell: kubectl apply -f /litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/spc.yml
+
+        - pause: 
+            seconds: 10
+        
+        ## Create Storage Class
+        - name: Create Storage class
+          shell: kubectl apply -f /litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/sc.yml
+        
+        ## Create namespace
+        - name: Create namespace
+          shell: kubectl create ns delete-spc
+        
+        ## Deploy minio application
+        - name: Deploy minio application
+          shell: kubectl apply -f /litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/template/minio-manifest
+
+        - pause:
+            seconds: 10
+
+        ## Delete SPC using director
+        - name: Delete SPC using director
+          uri: 
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/cstorpooloperations'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            headers:
+                Content-Type: "application/json"
+            body: '{"clusterId":"{{ cluster_id }}", "input":{"name":"spc-volume","kind":"StoragePoolClaim","version":"v1alpha1"}, "kind":"DeleteCStorPoolCluster"}'
+            status_code: 405
+          register: spc_deletion
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+        
+        
+
+        

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test.yml
@@ -33,7 +33,7 @@
 
         ## Create cstorPoolOperation
         - name: Get blockdevice 
-          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $1}' | tail -n 1
+          shell: kubectl get bd -n {{ namespace }} --no-headers | grep Unclaimed | awk '{print $1}' | tail -n 1
           register: blockdevice_name
         
         ## Add bd name in spc yml

--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test_vars.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test_vars.yml
@@ -1,0 +1,15 @@
+test_name: delete-spc-with-volume
+openebs_components:
+  [
+    'openebs-provisioner',
+    'openebs-ndm-operator',
+    'openebs-ndm',
+    'openebs-snapshot-operator',
+    'openebs-admission-server',
+    'openebs-localpv-provisioner',
+    'maya-apiserver',
+  ]
+group_id: "{{ lookup('env','GROUP_ID') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+director_url: "{{ lookup('env','DIRECTOR_IP') }}"
+namespace: "{{ lookup('env','NAMESPACE') }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Delete SPC via director which has volume 

**_Details:_**

**_Steps involved in openebs update in cluster:_**

- **Pre-checks**: 
  - Check whether all the openebs components are in running state or not.
  - DOP should be installed


- **Steps involved in the test case**
  - Create SPC using yaml
  - Invoke API to delete SPC
  - Delete SPC via director and it will give 405 error because application is using that pools in this test case.
  
#### Expected output:
- Negative test case
- Director should not delete the spc


**Additional Information-** 

| Title | Description |
| --- | --- |
|Assumptions | openebs should be already installed|
||Dop Installed |
| Application Under Test | Delete CSPC created via director which has volume  |
| Stogare Engine |  |
|Application Used| |
| Openebs Version | 1.10.0 |

**Notes to reviewer*


