### PR TITLE
Get the bd which is not attached to master node to create SPC

### DIFF
--- a/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-VOLUME/test.yml
@@ -31,9 +31,12 @@
           shell: | 
             kubectl get bd -n {{ namespace }}
 
-        ## Create cstorPoolOperation
-        - name: Get blockdevice 
-          shell: kubectl get bd -n {{ namespace }} --no-headers | grep Unclaimed | awk '{print $1}' | tail -n 1
+        - name: Get node details
+          shell: kubectl get node --selector='!node-role.kubernetes.io/master' --no-headers | awk '{print $1}' | tail -n 1
+          register: node_name
+        
+        - name: Get block blockdevice name
+          shell: kubectl get bd -n {{ namespace }} -l kubernetes.io/hostname={{ node_name.stdout }} | grep Unclaimed | awk '{print $1}' | tail -n 1
           register: blockdevice_name
         
         ## Add bd name in spc yml


### PR DESCRIPTION
- Earlier we were fetching the bd from any of the node so sometimes's it was taking disk which was attached to master node because of that sometimes application using bd was getting stuck in ContainerCreating state.

- This PR helps in fetching the bd which is not attached to master node.


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>

