### PR TITLE
fix(openebs-install): check node details of the cluster

### DIFF
--- a/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE/test.yml
+++ b/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE/test.yml
@@ -61,6 +61,7 @@
 
         ## Getting node details of the cluster
         ## Selecting the node which is in active state in the cluster
+        ## Retry till the data field in node details is empty
         - name: Getting the node details of the cluster which is in active state
           uri:
             url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes?state=active&clusterId={{ cluster_id }}"
@@ -72,6 +73,9 @@
             body_format: json
             status_code: 200
           register: node_details
+          until: "node_details.json.data != []"
+          delay: 2
+          retries: 10
 
         ## Define variable node_id
         - set_fact:
@@ -83,9 +87,13 @@
             node_id: "{{ node_id  + [item.id] }}"
           loop: "{{ node_details.json.data }}"
 
-        ## Openebs cleanup and label cleanup
-        - name: Openebs cleanup and label cleanup
+        ## Removing the labels from the cluster nodes
+        - name: Cleanup labels from the nodes
           include_tasks: /utils/openebs-label-cleanup.yml
+          when: "count_maya_api.stdout == '1'"
+
+        ## Deleting openebs from the cluster
+        - name: Cleanup openebs from the cluster
           include_tasks: /utils/openebs-cleanup.yml
           vars:
             namespace: "{{ openebs_namespace.stdout }}"

--- a/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS/test.yml
+++ b/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS/test.yml
@@ -44,6 +44,7 @@
 
         # Getting node details of the cluster
         ## Selecting the node which is in active state present in the cluster
+        ## Retry till the data field in node details is empty
         - name: Getting the node details of the cluster
           uri:
             url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes?state=active&clusterId={{ cluster_id }}"
@@ -56,6 +57,9 @@
             body:
               status_code: 202
           register: node_details
+          until: "node_details.json.data != []"
+          delay: 2
+          retries: 10
 
         ## Define variable node_id
         - set_fact:
@@ -67,8 +71,13 @@
             node_id: "{{ node_id  + [item.id] }}"
           loop: "{{ node_details.json.data }}"
 
-        - name: Openebs cleanup and label cleanup
+        ## Removing the labels from the cluster nodes
+        - name: Cleanup labels from the nodes
           include_tasks: /utils/openebs-label-cleanup.yml
+          when: "count_maya_api.stdout == '1'"
+
+        ## Deleting openebs from the cluster
+        - name: Cleanup openebs from the cluster
           include_tasks: /utils/openebs-cleanup.yml
           vars:
             namespace: "{{ openebs_namespace.stdout }}"


### PR DESCRIPTION
Signed-off-by: Harsh Shekhar <harshshekhar15@gmail.com>

This PR intends to do the following:
- Check node details of the cluster on which we want to install openebs. If the node details is empty retry until it gets updated with all the details.
- Fix label cleanup task.

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```



