### PR TITLE
[TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME]:Delete CSPC not created via director which has volume

### DIFF
--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/run_litmus_test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/run_litmus_test.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: delete-cspc-external-volume-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: delete-cspc-external-volume
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci 
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+
+          ## Takes director-ip from configmap director-ip
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Takes group-id from configmap group-id
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          - name: NAMESPACE
+            value: 'openebs'
+
+          ## Takes cluster_id from configmap
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      imagePullSecrets:
+      - name: oep-secret   

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/minio-manifest/minio-official.yaml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/minio-manifest/minio-official.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio-deploy-spc
+  namespace: delete-cspc-external
+  labels:
+    name: minio
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: minio
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        name: minio
+    spec:
+      # Refer to the PVC created earlier
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          # Name of the PVC created earlier
+                claimName: minio-claim-external
+      # nodeSelector:
+      #   kubernetes.io/os: linux
+      containers:
+      - name: minio
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio
+        args:
+        - server
+        - /storage
+        env:
+        # Minio access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+        # Mount the volume into the pod
+        volumeMounts:
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/minio-manifest/minio-pvc.yaml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/minio-manifest/minio-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-claim
+  namespace: delete-spc-external
+  labels:
+    app: minio-storage-claim
+spec:
+  storageClassName: cstor-external-cspc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 15G

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/minio-manifest/minio-svc.yaml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/minio-manifest/minio-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-svc
+  namespace: delete-spc-external
+  labels:
+    name: minio
+spec:
+  ports:
+    - port: 9000
+      nodePort: 32701
+      protocol: TCP
+  selector:
+    name: minio
+  sessionAffinity: None
+  type: NodePort
+

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/sc.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/sc.yml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: cstor-external-cspc
+provisioner: cstor.csi.openebs.io
+allowVolumeExpansion: true
+parameters:
+  cas-type: cstor
+  cstorPoolCluster: cspc-external-volume
+  replicaCount: "1"

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test.yml
@@ -1,0 +1,100 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        ## Getting the username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting the password.stdout     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        - name: Get BD
+          shell: | 
+            kubectl get bd -n {{ namespace }}
+
+        ## Get node name
+        - name: Get node name
+          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $2}' | tail -n 1
+          register: node_name
+        
+        - name: Create ns 
+          shell: kubectl create ns delete-cspc-external
+          
+        ## Add bd name in cspc yml
+        - name: Add bd name in cspc yml
+          shell: sed -i "s/nodeName/{{node_name.stdout}}/g" /utils/cspc.yml 
+
+        ## Create cstorPoolOperation
+        - name: Get blockdevice 
+          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $1}' | tail -n 1
+          register: blockdevice_name
+        
+        ## Add bd name in cspc yml
+        - name: Add bd name in cspc yml
+          shell: sed -i "s/dummyvalue/{{blockdevice_name.stdout}}/g" /utils/cspc.yml
+
+        ## Change name of the cspc
+        - name: Change name of cspc
+          shell: sed -i "s/cspc-external/cspc-external-volume/g" /utils/cspc.yml
+        
+        ## Create CSPC
+        - name: Create CSPC 
+          shell: kubectl create -f /utils/cspc.yml
+
+        - name: Create storage class
+          shell: kubectl create -f /litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/template/sc.yml
+
+        - name: Deploy application
+          shell: kubectl create -f 
+
+        - pause: 
+            seconds: 20
+
+        ## Delete CSPC using director
+        - name: Delete CSPC using director
+          uri: 
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/cstorpooloperations'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            headers:
+                Content-Type: "application/json"
+            body: '{"clusterId":"{{ cluster_id }}", "input":{"name":"cspc-external-volume","kind":"CStorPoolCluster","version":"v1"}, "kind":"DeleteCStorPoolCluster"}'
+            status_code: 405
+          register: cspc_deletion
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test_vars.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test_vars.yml
@@ -1,0 +1,15 @@
+test_name: delete-cspc-external-volume
+openebs_components:
+  [
+    'openebs-provisioner',
+    'openebs-ndm-operator',
+    'openebs-ndm',
+    'openebs-snapshot-operator',
+    'openebs-admission-server',
+    'openebs-localpv-provisioner',
+    'maya-apiserver',
+  ]
+group_id: "{{ lookup('env','GROUP_ID') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+director_url: "{{ lookup('env','DIRECTOR_IP') }}"
+namespace: "{{ lookup('env','NAMESPACE') }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

- CSPC not created via director which has volume

**_Details:_**

**_Steps involved in openebs update in cluster:_**

- **Pre-checks**: 
  - Check whether all the openebs components are in running state or not.
  - DOP should be installed


- **Steps involved in the test case**
  - Create CSPC using yaml
  - Invoke API to delete SPC
  - Delete CSPC via director and it will give 405 error because application is using that pools in this test case.
  
#### Expected output:
- Negative test case
- Director should not delete the spc


**Additional Information-** 

| Title | Description |
| --- | --- |
|Assumptions | openebs should be already installed|
||Dop Installed |
| Application Under Test | CSPC not created via director which has volume  |
| Stogare Engine |  |
|Application Used| |
| Openebs Version | 1.10.0 |

**Notes to reviewer*



