### PR TITLE
Refactored logic to select blockdevice which is unclaimed and does not contain any file system into it

### DIFF
--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test.yml
@@ -33,7 +33,7 @@
 
         ## Get node name
         - name: Get node name
-          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $2}' | tail -n 1
+          shell: kubectl get bd -n openebs -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.kubernetes\.io/hostname}{"\t"}{.status}{"\t"}{.spec.filesystem}{"\t"}{"\n"}{end}' | grep "Unclaimed" | grep -v "fsType" | awk {'print $2'} | tail -n 1
           register: node_name
 
         ## Add bd name in cspc yml
@@ -42,7 +42,7 @@
 
         ## Create cstorPoolOperation
         - name: Get blockdevice 
-          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $1}' | tail -n 1
+          shell: kubectl get bd -n openebs -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.kubernetes\.io/hostname}{"\t"}{.status}{"\t"}{.spec.filesystem}{"\t"}{"\n"}{end}' | grep "Unclaimed" | grep -v "fsType" | awk {'print $1'} | tail -n 1
           register: blockdevice_name
         
         ## Add bd name in cspc yml

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-NO-VOLUME/test.yml
@@ -36,8 +36,8 @@
           shell: kubectl get bd -n openebs -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.kubernetes\.io/hostname}{"\t"}{.status}{"\t"}{.spec.filesystem}{"\t"}{"\n"}{end}' | grep "Unclaimed" | grep -v "fsType" | awk {'print $2'} | tail -n 1
           register: node_name
 
-        ## Add bd name in cspc yml
-        - name: Add bd name in cspc yml
+        ## Add node name in cspc yml
+        - name: Add node  name in cspc yml
           shell: sed -i "s/nodeName/{{node_name.stdout}}/g" /utils/cspc.yml 
 
         ## Create cstorPoolOperation

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test.yml
@@ -39,8 +39,8 @@
         - name: Create ns 
           shell: kubectl create ns delete-cspc-external
 
-        ## Add bd name in cspc yml
-        - name: Add bd name in cspc yml
+        ## Add node name in cspc yml
+        - name: Add node name in cspc yml
           shell: sed -i "s/nodeName/{{node_name.stdout}}/g" /utils/cspc.yml 
 
         ## Create cstorPoolOperation

--- a/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test.yml
+++ b/litmus/director/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME/test.yml
@@ -33,7 +33,7 @@
 
         ## Get node name
         - name: Get node name
-          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $2}' | tail -n 1
+          shell: kubectl get bd -n openebs -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.kubernetes\.io/hostname}{"\t"}{.status}{"\t"}{.spec.filesystem}{"\t"}{"\n"}{end}' | grep "Unclaimed" | grep -v "fsType" | awk {'print $2'} | tail -n 1
           register: node_name
         
         - name: Create ns 
@@ -45,7 +45,7 @@
 
         ## Create cstorPoolOperation
         - name: Get blockdevice 
-          shell: kubectl get bd -n openebs --no-headers | grep Unclaimed | awk '{print $1}' | tail -n 1
+          shell: kubectl get bd -n openebs -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.kubernetes\.io/hostname}{"\t"}{.status}{"\t"}{.spec.filesystem}{"\t"}{"\n"}{end}' | grep "Unclaimed" | grep -v "fsType" | awk {'print $1'} | tail -n 1
           register: blockdevice_name
         
         ## Add bd name in cspc yml


### PR DESCRIPTION
### Why this PR required?
- Sometimes filesystem is getting created into the master node blockdevices. 
- And when we are using that device we are getting an error saying.
```
TASK [Create CSPC] *************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "kubectl create -f /utils/cspc.yml", "delta": "0:00:00.184331", "end": "2020-07-16 07:47:28.302378", "msg": "non-zero return code", "rc": 1, "start": "2020-07-16 07:47:28.118047", "stderr": "Error from server (BadRequest): error when creating \"/utils/cspc.yml\": admission webhook \"admission-webhook.cstor.openebs.io\" denied the request: invalid cspc specification: invalid pool spec: block device has file system {ext4}", "stderr_lines": ["Error from server (BadRequest): error when creating \"/utils/cspc.yml\": admission webhook \"admission-webhook.cstor.openebs.io\" denied the request: invalid cspc specification: invalid pool spec: block device has file system {ext4}"], "stdout": "", "stdout_lines": []}
```

###Solution:
- This PR helps in selecting block device name which doesn't have and filesystem into it.


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>


