### PR TITLE
Added check to verify openebs is installed or not via API

### DIFF
--- a/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR/test.yml
+++ b/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR/test.yml
@@ -41,6 +41,9 @@
           shell: | 
             kubectl get bd -n {{ namespace }}
 
+        - pause:	
+            minutes: 2
+
         ## Fetch the recommendation details
         - name: Fetch recommendations details
           uri:

--- a/litmus/director/TCID-DIR-OP-RE-INSTALL-OPENEBS/test.yml
+++ b/litmus/director/TCID-DIR-OP-RE-INSTALL-OPENEBS/test.yml
@@ -91,7 +91,7 @@
         ## This task will look for active openebs entry for 2 mins after that it will fail
         - name: Check openebs is installed or not in the cluster
           uri:
-            url: "{{ director_url }}/v3/groups/{{ group_id }}/openebses?state=active&clusterId={{ cluster_id}}"
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/openebses?state=active&clusterId={{ cluster_id }}"
             method: GET
             url_username: "{{ username.stdout }}" 
             url_password: "{{ password.stdout }}"

--- a/litmus/director/TCID-DIR-OP-RE-INSTALL-OPENEBS/test.yml
+++ b/litmus/director/TCID-DIR-OP-RE-INSTALL-OPENEBS/test.yml
@@ -87,6 +87,23 @@
           retries: 30
           delay: 10        
 
+        ## Check openebs is installed or not in the cluster.
+        ## This task will look for active openebs entry for 2 mins after that it will fail
+        - name: Check openebs is installed or not in the cluster
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/openebses?state=active&clusterId={{ cluster_id}}"
+            method: GET
+            url_username: "{{ username.stdout }}" 
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 200
+          register: openebses_active
+          until: "openebses_active.json.data != []"
+          delay: 2
+          retries: 30
+
         ## Getting node details of the cluster
         ## Selecting the node which is in active state in the cluster
         - name: Getting the node details of the cluster which is in active state


### PR DESCRIPTION
- This PR includes task which checks for the openebs entry in openebses entry.
- After installing openebs this task will check for the openebs `Active` entry.
- This task will retry for 2 minutes after installing opnebs for openebses active entry.

- I have also added 2 min sleep before creating cstor pool

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>



