### PR TITLE
Removing travis build code for testplan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ services:
 - docker
 script:
 - docker build -t $REPO:ci . ;
-- docker build -t $PLAN:$COMMIT ./testplan/ ;
 after_success:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then 
-   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && docker push $REPO:ci && docker push $PLAN:$COMMIT; 
+   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && docker push $REPO:ci; 
   fi


### PR DESCRIPTION
- Travis build is failing for testplan site due to some change in docusaurus. Due to this travis ci is failing for oep-e2e repo.
- We are removing the code for testplan build till docusaurus issue fixed.

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>




