### PR TITLE
feat(testplan): add troubleshooting section in testplan

### DIFF
--- a/testplan/docs/troubleshooting/aws.md
+++ b/testplan/docs/troubleshooting/aws.md
@@ -1,0 +1,7 @@
+---
+id: aws
+title: AWS Troubleshooting
+sidebar_label: AWS
+---
+
+## Issues

--- a/testplan/docs/troubleshooting/konvoy.md
+++ b/testplan/docs/troubleshooting/konvoy.md
@@ -1,0 +1,7 @@
+---
+id: konvoy
+title: Konvoy Troubleshooting
+sidebar_label: Konvoy
+---
+
+## Issues

--- a/testplan/docs/troubleshooting/rancher.md
+++ b/testplan/docs/troubleshooting/rancher.md
@@ -1,0 +1,43 @@
+---
+id: rancher
+title: Rancher Troubleshooting
+sidebar_label: Rancher
+---
+
+## Issues
+
+### Issue1: Openebs installation failing on cluster2
+
+#### What is the issue?
+
+In the Rancher pipeline, the installation of OpenEBS via Kubera OnPrem Director was stuck. On investigating more we found out that openebs-upgrade and cstorpoolauto pod present in maya-system namespace was showing the following error -
+
+```
+E0730 05:58:27.664789       1 discovery.go:184] API resource discovery failed: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request
+```
+
+On running kubectl get apiservices we got the below output -
+
+```
+NAME                                   SERVICE                      AVAILABLE                      AGE
+v1beta1.extensions                     Local                        True                           103d
+v1beta1.metrics.k8s.io                 kube-system/metrics-server   False (FailedDiscoveryCheck)   103d
+v1beta1.networking.k8s.io              Local                        True                           103d
+v1beta1.node.k8s.io                    Local                        True                           103d
+```
+
+On describing v1beta1.metrics.k8s.io we found out that it was showing the below message -
+
+```
+failing or missing response from https://10.43.124.28:443/apis/metrics.k8s.io/v1beta1: Get https://10.43.124.28:443/apis/metrics.k8s.io/v1beta1: dial tcp 10.43.124.28:443: connect: no route to host
+```
+
+On getting services present in all namespaces we found that 10.43.124.28 is the service of metrics-server and the logs of the metrics-server was showing the below error continuously -
+
+```
+E0729 19:29:05.246553       1 manager.go:111] unable to fully collect metrics: [unable to fully scrape metrics from source kubelet_summary:oep-rancher-node2: [unable to get CPU for node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "weave-plugins" in pod kube-system/weave-net-nbrz7 on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "weave" in pod kube-system/weave-net-nbrz7 on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "weave-npc" in pod kube-system/weave-net-nbrz7 on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "nginx-ingress-controller" in pod ingress-nginx/nginx-ingress-controller-2xzvq on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "agent" in pod cattle-system/cattle-node-agent-kgb2q on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "autoscaler" in pod kube-system/coredns-autoscaler-65bfc8d47d-4zj2n on node "10.53.1.12", discarding data: missing cpu usage metric], unable to fully scrape metrics from source kubelet_summary:oep-rancher-node1: unable to fetch metrics from Kubelet oep-rancher-node1 (10.53.1.11): Get https://10.53.1.11:10250/stats/summary?only_cpu_and_memory=true: dial tcp 10.53.1.11:10250: connect: connection refused]
+```
+
+#### How did we fix it?
+
+Restarting the metrics-server pod fixed the issue. So we restarted the metrics-server pod and took a snapshot of the VM’s of the cluster.

--- a/testplan/docs/troubleshooting/rancher.md
+++ b/testplan/docs/troubleshooting/rancher.md
@@ -12,9 +12,9 @@ sidebar_label: Rancher
 
 In the Rancher pipeline, the installation of OpenEBS via Kubera OnPrem Director was stuck. On investigating more we found out that openebs-upgrade and cstorpoolauto pod present in maya-system namespace was showing the following error -
 
-```
+`
 E0730 05:58:27.664789       1 discovery.go:184] API resource discovery failed: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request
-```
+`
 
 On running kubectl get apiservices we got the below output -
 
@@ -28,16 +28,22 @@ v1beta1.node.k8s.io                    Local                        True        
 
 On describing v1beta1.metrics.k8s.io we found out that it was showing the below message -
 
-```
+`
 failing or missing response from https://10.43.124.28:443/apis/metrics.k8s.io/v1beta1: Get https://10.43.124.28:443/apis/metrics.k8s.io/v1beta1: dial tcp 10.43.124.28:443: connect: no route to host
-```
+`
 
 On getting services present in all namespaces we found that 10.43.124.28 is the service of metrics-server and the logs of the metrics-server was showing the below error continuously -
 
-```
-E0729 19:29:05.246553       1 manager.go:111] unable to fully collect metrics: [unable to fully scrape metrics from source kubelet_summary:oep-rancher-node2: [unable to get CPU for node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "weave-plugins" in pod kube-system/weave-net-nbrz7 on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "weave" in pod kube-system/weave-net-nbrz7 on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "weave-npc" in pod kube-system/weave-net-nbrz7 on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "nginx-ingress-controller" in pod ingress-nginx/nginx-ingress-controller-2xzvq on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "agent" in pod cattle-system/cattle-node-agent-kgb2q on node "10.53.1.12", discarding data: missing cpu usage metric, unable to get CPU for container "autoscaler" in pod kube-system/coredns-autoscaler-65bfc8d47d-4zj2n on node "10.53.1.12", discarding data: missing cpu usage metric], unable to fully scrape metrics from source kubelet_summary:oep-rancher-node1: unable to fetch metrics from Kubelet oep-rancher-node1 (10.53.1.11): Get https://10.53.1.11:10250/stats/summary?only_cpu_and_memory=true: dial tcp 10.53.1.11:10250: connect: connection refused]
-```
+`
+E0730 00:09:50.263424       1 manager.go:111] unable to fully collect metrics: [unable to fully scrape metrics from source kubelet_summary:oep-rancher-node2: unable to get CPU for container "busybox" in pod openebs/busybox1 on node "10.53.1.12", discarding data: missing cpu usage metric, unable to fully scrape metrics from source kubelet_summary:oep-rancher-node5: unable to get a valid timestamp for metric point for container "fluentd-forwarder" in pod maya-system/fluentd-forwarder-mc7jh on node "10.53.1.15", discarding data: no non-zero timestamp on either CPU or memory]
+`
+
+The above log suggested that there were some time mismatch between the nodes of the cluster.
 
 #### How did we fix it?
 
-Restarting the metrics-server pod fixed the issue. So we restarted the metrics-server pod and took a snapshot of the VM’s of the cluster.
+To fix the timing mismatch issue, we set the correct time on each of the nodes. Restarting the metrics-server pod post setting the time resolved this issue. After restarting the pod we took a snapshot of the VM’s of the cluster.
+
+#### Issue link
+
+- https://github.com/mayadata-io/oep/issues/220

--- a/testplan/docs/troubleshooting/rancher.md
+++ b/testplan/docs/troubleshooting/rancher.md
@@ -16,7 +16,7 @@ In the Rancher pipeline, the installation of OpenEBS via Kubera OnPrem Director 
 E0730 05:58:27.664789       1 discovery.go:184] API resource discovery failed: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request
 `
 
-On running kubectl get apiservices we got the below output -
+On running `kubectl get apiservices` we got the below output -
 
 ```
 NAME                                   SERVICE                      AVAILABLE                      AGE

--- a/testplan/sidebars.js
+++ b/testplan/sidebars.js
@@ -199,7 +199,14 @@ module.exports = {
             'manual/kubera-openebs-upgrade', 
             'manual/kubera-openebs-installation', 
             'manual/kubera-cstor-pool' 
-        ],
+		],
+		
+		"Troubleshooting": [
+			'troubleshooting/aws',
+			'troubleshooting/rancher',
+			'troubleshooting/konvoy'
+		],
+		
         Help: ['doc1', 'mdx'],
 	},
 };


### PR DESCRIPTION
Signed-off-by: Harsh Shekhar <harsh.shekhar@mayadata.io>

This PR intends to do the following:
- Add `Troubleshooting` section in testplan site.
- Add Rancher troubleshooting docs.

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```



