### PR TITLE
Added few more path in EXCLUDE_DEVICE_FILTER to so that these disks are not used to create BD

### DIFF
--- a/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE/run_litmus_test.yml
+++ b/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE/run_litmus_test.yml
@@ -69,7 +69,7 @@ spec:
           ## we can remove /dev/sdb disk from the ndm configmap and
           ## this disk will not be used as a block-device for openebs related test cases
           - name: EXCLUDE_DEVICE_FILTER
-            value: '/dev/sdb'
+            value: 'loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/sdb'
 
           ## CPU resource limit is provided
           - name: CPU_RESOURCE_LIMIT


### PR DESCRIPTION
- Added few more path values in `EXCLUDE_DEVICE_FILTER` from the ndm configmap and these disk will not be used as a block-device for openebs related test cases.


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>
