### PR TITLE
feat(add): script to monitor lab infra

### DIFF
--- a/monitor/actions.go
+++ b/monitor/actions.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func restartGitlabRunners() {
+	_, config := loadConfig()
+	for _, val := range config {
+		Command := sshToRunners + val + " --command" + " 'systemctl restart gitlab-runner'" + " > /dev/null && echo true || echo false"
+		output, _ := exec.Command("/bin/sh", "-c", Command).Output()
+		commandOutput := (string(output))
+		if strings.Contains(string(commandOutput), "true") {
+			fmt.Printf(getTime()+" Restarted Runner %s\n", val)
+		} else {
+			fmt.Printf(getTime()+" Unable to Restarted Runner %s\n", val)
+		}
+	}
+}
+
+//Checks wheether IP table rules exists inside landing machine
+//sshpass should be installed inside container
+func isIpTablesFlushed() bool {
+	Command := sshToLandingMachine + "'iptables -L'"
+	output, _ := exec.Command("/bin/sh", "-c", Command).Output()
+	commandOutput := (string(output))
+	if strings.Contains(string(commandOutput), "master-1551782451.mayalabs.io") {
+		fmt.Printf(getTime() + " IPtables EXISTS\n")
+		return false
+	}
+	fmt.Printf(getTime() + " IPtables does not EXIST\n")
+	return true
+}
+
+//Restore the IP table rules in Landing machine
+func restoreIpTables() {
+	fmt.Printf(getTime() + " Restoreing IPtables")
+	Command := sshToLandingMachine + "'cd test && iptables-restore < ip_tables.out_26April2020'"
+	exec.Command("/bin/sh", "-c", Command).Output()
+}
+
+//Checks whether ESX is reachable from landing machine or not
+func isEsxRechable(esxIP string) bool {
+	Command := sshToLandingMachine + "'ping -c 1 " + esxIP + " > /dev/null && echo true || echo false'"
+	output, _ := exec.Command("/bin/sh", "-c", Command).Output()
+	commandOutput := (string(output))
+	if strings.Contains(string(commandOutput), "false") {
+		fmt.Printf(getTime()+" ESX-%s is not reachable\n", esxIP)
+		return false
+	}
+	fmt.Printf(getTime()+" ESX-%s is reachable\n", esxIP)
+	return true
+
+}
+
+//Power on the VM inside all the available ESX
+func powerOnVms() {
+	config, _ := loadConfig()
+	for key, _ := range config {
+		if isEsxRechable(key) == true {
+			fmt.Printf(getTime()+" Checking for turned off VMs in ESX-%s\n", key)
+			vmId := config[key]
+			for _, item := range vmId {
+				powerOn(key, item)
+			}
+		}
+	}
+}
+
+//power on the VMs inside particular ESX
+func powerOn(esxIP string, vmId string) {
+	Command := sshToLandingMachine + "'sshpass ssh -o StrictHostKeyChecking=no root@" + esxIP + " 'vim-cmd vmsvc/power.on " + vmId + "'" + "'" + " > /dev/null && echo true || echo false"
+	output, _ := exec.Command("/bin/sh", "-c", Command).Output()
+	commandOutput := (string(output))
+	if strings.Contains(string(commandOutput), "true") {
+		fmt.Printf(getTime()+" Powered on VM with id %s in ESX-%s\n", vmId, esxIP)
+	}
+}

--- a/monitor/config.go
+++ b/monitor/config.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var (
+	landingMachineIP       string
+	landingMachineUser     string
+	sshPort                string
+	gitlabUrl              string
+	landingMachinePassword string
+	sshToLandingMachine    string
+	sshToRunners           string
+	zone                   string
+	gcpPojectID            string
+	poolInterval           int //Pooling time interval in sec
+)
+
+//ESX-to-VM mapping
+func loadConfig() (map[string][]string, []string) {
+	vmMapping := map[string][]string{
+		"10.21.1.1": []string{"1", "2"},
+		"10.22.1.1": []string{"15", "16", "17", "18", "19", "20"},
+		"10.51.1.1": []string{"27", "28", "29", "30", "31", "32"},
+		"10.58.1.1": []string{"7", "8"},
+	}
+	runners := []string{"aws-pipeline-runner", "k8s-native-gitlab-runner", "konvoy--istaller-autoscalar", "openshift-autoscalar"}
+	return vmMapping, runners
+}
+
+//Fetches all the supported Envirnment varibles
+func initializeEnvValues() error {
+	var err error
+	landingMachineIP, err = getEnv("LANDING_MACHINE_IP")
+	if err != nil {
+		return err
+	}
+	landingMachineUser, err = getEnv("LANDING_MACHINE_USER")
+	if err != nil {
+		return err
+	}
+	sshPort, err = getEnv("SSH_PORT")
+	if err != nil {
+		return err
+	}
+	gitlabUrl, err = getEnv("GITLAB_URL")
+	if err != nil {
+		return err
+	}
+	landingMachinePassword, err = getEnv("LANDING_MACHINE_PASSWORD")
+	if err != nil {
+		return err
+	}
+	gcpPojectID, err = getEnv("PROJECT_ID")
+	if err != nil {
+		return err
+	}
+	zone, err := getEnv("ZONE")
+	if err != nil {
+		return err
+	}
+	tmppoolInterval, err := getEnv("POOL_TIME")
+	if err != nil {
+		return err
+	}
+	poolInterval, err = strconv.Atoi(tmppoolInterval)
+	if err != nil {
+		return err
+	}
+	sshToLandingMachine = "sshpass" + " -p" + landingMachinePassword + " ssh -o StrictHostKeyChecking=no " + landingMachineUser + "@" + landingMachineIP + " -p " + sshPort + " "
+	sshToRunners = "gcloud compute ssh --project " + gcpPojectID + " --zone " + zone + " root@"
+	return nil
+}
+
+func getEnv(key string) (string, error) {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return "", fmt.Errorf("ENV %s not found", key)
+	}
+	return value, nil
+}

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "sync"
+
+func main() {
+	initializeEnvValues()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go poolLandingMachine()
+	go poolGitlab()
+	wg.Wait()
+}

--- a/monitor/pooling.go
+++ b/monitor/pooling.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func poolGitlab() {
+	errReport, unreachable, reachable := false, false, false
+	for true {
+		resp, err := http.Get(gitlabUrl)
+		if err != nil {
+			fmt.Println(getTime()+" ", err)
+			time.Sleep(10 * time.Second)
+			//action performed when gitlab is down(based on variable errReport) will not be repeated.
+			if errReport == false {
+				if isIpTablesFlushed() == true {
+					restoreIpTables()
+				}
+				powerOnVms()
+				errReport = true
+				reachable = false
+			}
+
+		}
+		if resp != nil {
+			if resp.StatusCode != 200 {
+				if unreachable == false {
+					fmt.Printf(getTime()+" Gitlab is down with status code: %d\n", resp.StatusCode)
+					if isIpTablesFlushed() == true {
+						restoreIpTables()
+					}
+					powerOnVms()
+					unreachable = true
+					reachable = false
+				}
+			}
+			//Condition when Gitlab is up
+			if resp.StatusCode == 200 {
+				if reachable == false {
+					fmt.Printf(getTime()+" Gitlab is Up with status code: %d\n", resp.StatusCode)
+					if unreachable == true || errReport == true {
+						restartGitlabRunners()
+					}
+					errReport = false
+					unreachable = false
+					reachable = true
+				}
+			}
+		}
+		time.Sleep(time.Duration(poolInterval) * time.Second)
+	}
+}
+
+func isLandingMachineReachable() bool {
+	Command := "ping -c 1" + " " + landingMachineIP + " > " + "/dev/null && echo true || echo false"
+	output, _ := exec.Command("/bin/sh", "-c", Command).Output()
+	commandOutput := (string(output))
+	if strings.Contains(string(commandOutput), "false") {
+		return false
+	}
+	return true
+}
+
+func poolLandingMachine() {
+	unreachable, reachable := false, false
+	for true {
+		if isLandingMachineReachable() == false {
+			if unreachable == false {
+				fmt.Println(getTime(), "landing machine is not reachable")
+				unreachable = true
+				reachable = false
+			}
+		} else {
+			if reachable == false {
+				fmt.Println(getTime(), "landing machine is reachable")
+				if isIpTablesFlushed() == true {
+					restoreIpTables()
+					powerOnVms()
+				}
+				reachable = true
+				unreachable = false
+			}
+		}
+		time.Sleep(time.Duration(poolInterval) * time.Second)
+	}
+}
+
+func getTime() string {
+	currentTime := string(time.Now().Format("2006-01-02 15:04:05"))
+	formatTime := "[" + currentTime + "]"
+	return formatTime
+}


### PR DESCRIPTION
Signed-off-by: <ranjanshashank855@gmail.com>

## Why do we need this PR
- Continuously monitor for Gitlab and lab network and performs actions when either is down.

## Special notes for your reviewer:

- Script pools for two instances *Gitlab* & *Landing Machine*.

- Following actions are performed when either goes down
   
     - Restore the IP tables if does not exist in landing machine.
     - Start the necessary VM by iterating over ESX.
     - Restart the Gitlab Runners.


