### PR TITLE
Fetch openebs_target_version from upgradematrixs endpoint to upgrade openebs control plane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ services:
 - docker
 script:
 - docker build -t $REPO:ci . ;
-- docker build -t $PLAN:$COMMIT ./testplan/ ;
+## - docker build -t $PLAN:$COMMIT ./testplan/ ;
 after_success:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then 
-   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && docker push $REPO:ci && docker push $PLAN:$COMMIT; 
+   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && docker push $REPO:ci;
   fi

--- a/litmus/director/TCID-DIR-OP-OPENEBS-UPGRADE-CP/test.yml
+++ b/litmus/director/TCID-DIR-OP-OPENEBS-UPGRADE-CP/test.yml
@@ -290,10 +290,26 @@
           retries: 50
           delay: 5
 
-        ## Fetching latest version
-        - name: Fetching latest version
+        ## Fetch upgradematrix details
+        ## upgradematrix includes list of supported Base versions openebs_current_version
+        ## is not in list of upgradematrix.
+        - name: Fetch upgradematrixs details
+          uri:
+            url: "{{ director_url }}/v3/upgradematrixes"
+            method: GET
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 200,201,202
+          register: upgradematrixes
+          failed_when: openebs_current_version not in upgradematrixes.json.data[0].supportedBaseVersions
+
+        ## Fetch latest version from upgradematrix
+        - name: Fetch latest version from upgradematrix
           set_fact:
-            openebs_target_version: "{{ template_details.json.data[0].version }}"
+            openebs_target_version: "{{ upgradematrixes.json.data[0].targetVersion }}"
         
         ## Upgrading openebs control plane components
         - name: Upgrading openebs control plane components


### PR DESCRIPTION
# Description

- This PR intends to fetch `openebs_target_version` from upgradematrixs endpoint.
- Earlier we used to fetch version from openebs templates but due to some change in API now it is recommended to fetch version from upgradematrixs.
- And also added check if `openebs_current_version` is not in `supportedBaseVersions` then it should fail.
- Commented tesplan build steps as the build is failing.


### Fixes # (issue)
https://github.com/mayadata-io/oep-e2e/issues/886


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update




# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules