### PR TITLE
feat(chaos): add kubelet-restart chaos test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,3 +49,6 @@ RUN curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2
 RUN chmod +x /usr/local/bin/aws-iam-authenticator
 RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 RUN mv /tmp/eksctl /usr/local/bin
+
+# Install Docker
+RUN apk add docker

--- a/litmus/director/TCID-KUBELET-RESTART/run_litmus_test.yml
+++ b/litmus/director/TCID-KUBELET-RESTART/run_litmus_test.yml
@@ -1,0 +1,47 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: kubelet-restart-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: kubelet-restart
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        env:
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Namespace in which Kubera is deployed
+          - name: KUBERA_NAMESPACE
+            value: default
+
+            # Platform on which the test is being run
+          - name: PLATFORM
+            value: platform_name
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/TCID-KUBELET-RESTART/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        volumeMounts:
+          - name: dockersock
+            mountPath: "/var/run/docker.sock"
+      volumes:
+        # Mount the socket to use docker running on the node
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+          type: File
+      imagePullSecrets:
+      - name: oep-secret

--- a/litmus/director/TCID-KUBELET-RESTART/run_litmus_test.yml
+++ b/litmus/director/TCID-KUBELET-RESTART/run_litmus_test.yml
@@ -43,5 +43,6 @@ spec:
         hostPath:
           path: /var/run/docker.sock
           type: File
+      # Secret used to pull mayadataio/dop-validator:ci image
       imagePullSecrets:
       - name: oep-secret

--- a/litmus/director/TCID-KUBELET-RESTART/test.yml
+++ b/litmus/director/TCID-KUBELET-RESTART/test.yml
@@ -41,11 +41,15 @@
           # Restart Kubelet based on platform
         - block:
 
-            # Restart Kubelet container present on the node
-          - name: Restarting Kubelet container in Rancher
-            shell: docker restart kubelet
+            # Stop Kubelet container present on the node
+          - name: Stopping Kubelet container in Rancher
+            shell: echo "Stopping kubelet container - "{{ item }}"" && docker stop kubelet && sleep 2
+            loop: "{{ range(0, 210, 1)|list }}"
 
           when: platform == "RANCHER"
+
+        - name: Printing the status of nodes of the cluster
+          shell: kubectl get nodes -o wide
 
           # Check Kubera pod status
           # Task will fail if all the pods are not in 'Running' phase
@@ -54,7 +58,7 @@
           register: podStatus
           until: podStatus.stdout == ""
           delay: 10
-          retries: 12
+          retries: 18
 
           # Check Kubera pods container's state
           # Task will fail if all the containers are not in 'Ready' state

--- a/litmus/director/TCID-KUBELET-RESTART/test.yml
+++ b/litmus/director/TCID-KUBELET-RESTART/test.yml
@@ -1,0 +1,71 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          # Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+          # RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+         # Restart Kubelet based on platform
+        - block:
+
+            # Restart Kubelet container present on the node
+          - name: Restarting Kubelet container in Rancher
+            shell: docker restart kubelet
+
+          when: platform == "RANCHER"
+
+          # Check Kubera pod status
+          # Task will fail if all the pods are not in 'Running' phase
+        - name: Checking Kubera pods status
+          shell: kubectl get pods -n {{ kuberaNamespace }} --field-selector=status.phase!=Running --no-headers
+          register: podStatus
+          until: podStatus.stdout == ""
+          delay: 10
+          retries: 12
+
+          # Check Kubera pods container's state
+          # Task will fail if all the containers are not in 'Ready' state
+        - name: Checking Kubera pods container's state
+          shell: >
+            kubectl get pod -n {{ kuberaNamespace }} --no-headers
+            -o jsonpath='{.items[*].status.containerStatuses[*].ready}' | tr ' ' '\n' | uniq
+          args:
+            executable: /bin/bash
+          register: containerStatus
+          until: containerStatus.stdout == "true"
+          delay: 10
+          retries: 12
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+      
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+        
+        - name: Print the task where the testcase failed
+          debug:
+            msg: Testcase failed at TASK - {{ ansible_failed_task.name }}
+        
+        - name: Print the ERROR with which the task failed
+          debug:
+            msg: ERROR - {{ ansible_failed_result }}
+
+      always:
+          # RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/TCID-KUBELET-RESTART/test.yml
+++ b/litmus/director/TCID-KUBELET-RESTART/test.yml
@@ -16,7 +16,29 @@
           vars:
             status: 'SOT'
 
-         # Restart Kubelet based on platform
+          # Check Kubera pod status before running chaos
+          # Task will fail if all the pods are not in 'Running' phase
+        - name: Checking Kubera pods status before running chaos
+          shell: kubectl get pods -n {{ kuberaNamespace }} --field-selector=status.phase!=Running --no-headers
+          register: initialPodStatus
+          until: initialPodStatus.stdout == ""
+          delay: 10
+          retries: 12
+
+          # Check Kubera pods container's state before running chaos
+          # Task will fail if all the containers are not in 'Ready' state
+        - name: Checking Kubera pods container's state before running chaos
+          shell: >
+            kubectl get pod -n {{ kuberaNamespace }} --no-headers
+            -o jsonpath='{.items[*].status.containerStatuses[*].ready}' | tr ' ' '\n' | uniq
+          args:
+            executable: /bin/bash
+          register: initialContainerStatus
+          until: initialContainerStatus.stdout == "true"
+          delay: 10
+          retries: 12
+
+          # Restart Kubelet based on platform
         - block:
 
             # Restart Kubelet container present on the node

--- a/litmus/director/TCID-KUBELET-RESTART/test_vars.yml
+++ b/litmus/director/TCID-KUBELET-RESTART/test_vars.yml
@@ -1,0 +1,2 @@
+kuberaNamespace: "{{ lookup('env','KUBERA_NAMESPACE') }}"
+platform: "{{ lookup('env','PLATFORM')}}"


### PR DESCRIPTION
Signed-off-by: Harsh Shekhar <harsh.shekhar@mayadata.io>

This PR intends to do the following:
- Add Kubera chaos test - `TCID-KUBELET-RESTART`.
- Add docker install in Dockerfile.

<!--
Hi, thank you for creating an PR!

Please fill in as much of the template below as you can in order to help reviewer.

Thank you!
-->

#### Exact application name that is under test.
<!-- Mongo, cassandra, etc-->

#### Storage engine that is under test
<!-- Jiva, cStor, etc-->

#### OpenEBS version if required.

####  Assumptions of this PR
<!-- openebs should be installed, cstor pool should be available, 3 node cluster,etc -->

#### Notes to reviewer.
<!-- dependent PRs or issues or doc links. Mention if other PRs need to be merged. Or this PR needs to be merged before other PRs.-->

#### Anything else we need to know?
<!-- Cloud provider? Hardware? How did you configure your cluster? Kubernetes YAML, KOPS, etc. -->

#### Versions:
<!-- Please paste in the output of these commands; 'kubectl' only if using Kubernetes -->
```
$ Kubernetes version
$ Kubernetes platform
$ kubectl version

```



