### PR TITLE
node version update

### DIFF
--- a/testplan/Dockerfile
+++ b/testplan/Dockerfile
@@ -1,7 +1,7 @@
 #-----------------------------
 # build testplan site
 #-----------------------------
-FROM node:10.16.0 AS build-env
+FROM node:10.18.0 AS build-env
 
 WORKDIR /app/
 


### PR DESCRIPTION
Build getting failed because of node version not compatiable with latest node packages ,

```sh
error @ava/babel@1.0.1: The engine "node" is incompatible with this module. Expected version ">=10.18.0 <11 || >=12.14.0 <13 || >=13.5.0". Got "10.16.0"
``
failed build : https://travis-ci.com/github/mayadata-io/oep-e2e/builds/199683619#L6897